### PR TITLE
add missing fields of case to 4 centric indices

### DIFF
--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -20,11 +20,13 @@ properties:
     copy_to:
     - case_autocomplete
   created_datetime:
-    type: keyword
+    type: date
+  days_to_index:
+    type: long
   demographic:
     properties:
       created_datetime:
-        type: keyword
+        type: date
       demographic_id:
         type: keyword
       ethnicity:
@@ -48,27 +50,97 @@ properties:
     properties:
       age_at_diagnosis:
         type: long
+      ajcc_clinical_m:
+        type: keyword
+      ajcc_clinical_n:
+        type: keyword
+      ajcc_clinical_stage:
+        type: keyword
+      ajcc_clinical_t:
+        type: keyword
+      ajcc_pathologic_m:
+        type: keyword
+      ajcc_pathologic_n:
+        type: keyword
+      ajcc_pathologic_stage:
+        type: keyword
+      ajcc_pathologic_t:
+        type: keyword
+      ann_arbor_b_symptoms:
+        type: keyword
+      ann_arbor_clinical_stage:
+        type: keyword
+      ann_arbor_extranodal_involvement:
+        type: keyword
+      ann_arbor_pathologic_stage:
+        type: keyword
+      burkitt_lymphoma_clinical_variant:
+        type: keyword
+      cause_of_death:
+        type: keyword
+      circumferential_resection_margin:
+        type: long
       classification_of_tumor:
         type: keyword
-      created_datetime:
+      colon_polyps_history:
         type: keyword
+      created_datetime:
+        type: date
       days_to_birth:
         type: long
       days_to_death:
         type: long
+      days_to_hiv_diagnosis:
+        type: long
       days_to_last_follow_up:
+        type: long
+      days_to_last_known_disease_status:
+        type: long
+      days_to_new_event:
+        type: long
+      days_to_recurrence:
         type: long
       diagnosis_id:
         type: keyword
+      figo_stage:
+        type: keyword
+      hiv_positive:
+        type: keyword
+      hpv_positive_type:
+        type: keyword
+      hpv_status:
+        type: keyword
       last_known_disease_status:
         type: keyword
+      laterality:
+        type: keyword
+      ldh_level_at_diagnosis:
+        type: long
+      ldh_normal_range_upper:
+        type: long
+      lymph_nodes_positive:
+        type: long
+      lymphatic_invasion_present:
+        type: keyword
+      method_of_diagnosis:
+        type: keyword
       morphology:
+        type: keyword
+      new_event_anatomic_site:
+        type: keyword
+      new_event_type:
+        type: keyword
+      perineural_invasion_present:
         type: keyword
       primary_diagnosis:
         type: keyword
       prior_malignancy:
         type: keyword
+      prior_treatment:
+        type: keyword
       progression_or_recurrence:
+        type: keyword
+      residual_disease:
         type: keyword
       site_of_resection_or_biopsy:
         type: keyword
@@ -79,9 +151,10 @@ properties:
       tissue_or_organ_of_origin:
         type: keyword
       treatments:
+        type: nested
         properties:
           created_datetime:
-            type: keyword
+            type: date
           days_to_treatment:
             type: long
           days_to_treatment_end:
@@ -114,25 +187,44 @@ properties:
         type: keyword
       updated_datetime:
         type: date
+      vascular_invasion_present:
+        type: keyword
       vital_status:
         type: keyword
+      year_of_diagnosis:
+        type: long
   disease_type:
     type: keyword
     copy_to:
     - case_autocomplete
   exposures:
+    type: nested
     properties:
+      alcohol_history:
+        type: keyword
+      alcohol_intensity:
+        type: keyword
       bmi:
         type: float
       cigarettes_per_day:
         type: float
+      created_datetime:
+        type: date
       exposure_id:
         type: keyword
       height:
         type: float
+      pack_years_smoked:
+        type: long
       state:
         type: keyword
       submitter_id:
+        type: keyword
+      tobacco_smoking_onset_year:
+        type: long
+      tobacco_smoking_quit_year:
+        type: long
+      tobacco_smoking_status:
         type: keyword
       updated_datetime:
         type: date
@@ -140,6 +232,29 @@ properties:
         type: float
       years_smoked:
         type: float
+  family_histories:
+    type: nested
+    properties:
+      created_datetime:
+        type: date
+      family_history_id:
+        type: keyword
+      relationship_age_at_diagnosis:
+        type: long
+      relationship_gender:
+        type: keyword
+      relationship_primary_diagnosis:
+        type: keyword
+      relationship_type:
+        type: keyword
+      relative_with_cancer_history:
+        type: keyword
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: date
   gene:
     type: nested
     properties:
@@ -385,8 +500,6 @@ properties:
                 type: long
               start_phase:
                 type: long
-          transcript_id:
-            type: keyword
           is_canonical:
             type: boolean
           length:
@@ -407,6 +520,8 @@ properties:
             type: long
           start_exon:
             type: long
+          transcript_id:
+            type: keyword
           translation_id:
             type: keyword
   primary_site:
@@ -415,10 +530,14 @@ properties:
     - case_autocomplete
   project:
     properties:
+      dbgap_accession_number:
+        type: keyword
       disease_type:
         type: keyword
         copy_to:
         - case_autocomplete
+      intended_release_date:
+        type: keyword
       name:
         type: keyword
         copy_to:
@@ -439,6 +558,8 @@ properties:
         type: keyword
         copy_to:
         - case_autocomplete
+      releasable:
+        type: keyword
       released:
         type: boolean
       state:
@@ -459,6 +580,7 @@ properties:
           file_count:
             type: long
       experimental_strategies:
+        type: nested
         properties:
           experimental_strategy:
             type: keyword

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -19,11 +19,13 @@ properties:
       case_id:
         type: keyword
       created_datetime:
-        type: keyword
+        type: date
+      days_to_index:
+        type: long
       demographic:
         properties:
           created_datetime:
-            type: keyword
+            type: date
           demographic_id:
             type: keyword
           ethnicity:
@@ -47,27 +49,97 @@ properties:
         properties:
           age_at_diagnosis:
             type: long
+          ajcc_clinical_m:
+            type: keyword
+          ajcc_clinical_n:
+            type: keyword
+          ajcc_clinical_stage:
+            type: keyword
+          ajcc_clinical_t:
+            type: keyword
+          ajcc_pathologic_m:
+            type: keyword
+          ajcc_pathologic_n:
+            type: keyword
+          ajcc_pathologic_stage:
+            type: keyword
+          ajcc_pathologic_t:
+            type: keyword
+          ann_arbor_b_symptoms:
+            type: keyword
+          ann_arbor_clinical_stage:
+            type: keyword
+          ann_arbor_extranodal_involvement:
+            type: keyword
+          ann_arbor_pathologic_stage:
+            type: keyword
+          burkitt_lymphoma_clinical_variant:
+            type: keyword
+          cause_of_death:
+            type: keyword
+          circumferential_resection_margin:
+            type: long
           classification_of_tumor:
             type: keyword
-          created_datetime:
+          colon_polyps_history:
             type: keyword
+          created_datetime:
+            type: date
           days_to_birth:
             type: long
           days_to_death:
             type: long
+          days_to_hiv_diagnosis:
+            type: long
           days_to_last_follow_up:
+            type: long
+          days_to_last_known_disease_status:
+            type: long
+          days_to_new_event:
+            type: long
+          days_to_recurrence:
             type: long
           diagnosis_id:
             type: keyword
+          figo_stage:
+            type: keyword
+          hiv_positive:
+            type: keyword
+          hpv_positive_type:
+            type: keyword
+          hpv_status:
+            type: keyword
           last_known_disease_status:
             type: keyword
+          laterality:
+            type: keyword
+          ldh_level_at_diagnosis:
+            type: long
+          ldh_normal_range_upper:
+            type: long
+          lymph_nodes_positive:
+            type: long
+          lymphatic_invasion_present:
+            type: keyword
+          method_of_diagnosis:
+            type: keyword
           morphology:
+            type: keyword
+          new_event_anatomic_site:
+            type: keyword
+          new_event_type:
+            type: keyword
+          perineural_invasion_present:
             type: keyword
           primary_diagnosis:
             type: keyword
           prior_malignancy:
             type: keyword
+          prior_treatment:
+            type: keyword
           progression_or_recurrence:
+            type: keyword
+          residual_disease:
             type: keyword
           site_of_resection_or_biopsy:
             type: keyword
@@ -78,9 +150,10 @@ properties:
           tissue_or_organ_of_origin:
             type: keyword
           treatments:
+            type: nested
             properties:
               created_datetime:
-                type: keyword
+                type: date
               days_to_treatment:
                 type: long
               days_to_treatment_end:
@@ -113,23 +186,42 @@ properties:
             type: keyword
           updated_datetime:
             type: date
+          vascular_invasion_present:
+            type: keyword
           vital_status:
             type: keyword
+          year_of_diagnosis:
+            type: long
       disease_type:
         type: keyword
       exposures:
+        type: nested
         properties:
+          alcohol_history:
+            type: keyword
+          alcohol_intensity:
+            type: keyword
           bmi:
             type: float
           cigarettes_per_day:
             type: float
+          created_datetime:
+            type: date
           exposure_id:
             type: keyword
           height:
             type: float
+          pack_years_smoked:
+            type: long
           state:
             type: keyword
           submitter_id:
+            type: keyword
+          tobacco_smoking_onset_year:
+            type: long
+          tobacco_smoking_quit_year:
+            type: long
+          tobacco_smoking_status:
             type: keyword
           updated_datetime:
             type: date
@@ -137,11 +229,38 @@ properties:
             type: float
           years_smoked:
             type: float
+      family_histories:
+        type: nested
+        properties:
+          created_datetime:
+            type: date
+          family_history_id:
+            type: keyword
+          relationship_age_at_diagnosis:
+            type: long
+          relationship_gender:
+            type: keyword
+          relationship_primary_diagnosis:
+            type: keyword
+          relationship_type:
+            type: keyword
+          relative_with_cancer_history:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: date
       primary_site:
         type: keyword
       project:
         properties:
+          dbgap_accession_number:
+            type: keyword
           disease_type:
+            type: keyword
+          intended_release_date:
             type: keyword
           name:
             type: keyword
@@ -156,6 +275,8 @@ properties:
               program_id:
                 type: keyword
           project_id:
+            type: keyword
+          releasable:
             type: keyword
           released:
             type: boolean
@@ -326,6 +447,7 @@ properties:
               file_count:
                 type: long
           experimental_strategies:
+            type: nested
             properties:
               experimental_strategy:
                 type: keyword

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -140,11 +140,13 @@ properties:
           case_id:
             type: keyword
           created_datetime:
-            type: keyword
+            type: date
+          days_to_index:
+            type: long
           demographic:
             properties:
               created_datetime:
-                type: keyword
+                type: date
               demographic_id:
                 type: keyword
               ethnicity:
@@ -168,27 +170,97 @@ properties:
             properties:
               age_at_diagnosis:
                 type: long
+              ajcc_clinical_m:
+                type: keyword
+              ajcc_clinical_n:
+                type: keyword
+              ajcc_clinical_stage:
+                type: keyword
+              ajcc_clinical_t:
+                type: keyword
+              ajcc_pathologic_m:
+                type: keyword
+              ajcc_pathologic_n:
+                type: keyword
+              ajcc_pathologic_stage:
+                type: keyword
+              ajcc_pathologic_t:
+                type: keyword
+              ann_arbor_b_symptoms:
+                type: keyword
+              ann_arbor_clinical_stage:
+                type: keyword
+              ann_arbor_extranodal_involvement:
+                type: keyword
+              ann_arbor_pathologic_stage:
+                type: keyword
+              burkitt_lymphoma_clinical_variant:
+                type: keyword
+              cause_of_death:
+                type: keyword
+              circumferential_resection_margin:
+                type: long
               classification_of_tumor:
                 type: keyword
-              created_datetime:
+              colon_polyps_history:
                 type: keyword
+              created_datetime:
+                type: date
               days_to_birth:
                 type: long
               days_to_death:
                 type: long
+              days_to_hiv_diagnosis:
+                type: long
               days_to_last_follow_up:
+                type: long
+              days_to_last_known_disease_status:
+                type: long
+              days_to_new_event:
+                type: long
+              days_to_recurrence:
                 type: long
               diagnosis_id:
                 type: keyword
+              figo_stage:
+                type: keyword
+              hiv_positive:
+                type: keyword
+              hpv_positive_type:
+                type: keyword
+              hpv_status:
+                type: keyword
               last_known_disease_status:
                 type: keyword
+              laterality:
+                type: keyword
+              ldh_level_at_diagnosis:
+                type: long
+              ldh_normal_range_upper:
+                type: long
+              lymph_nodes_positive:
+                type: long
+              lymphatic_invasion_present:
+                type: keyword
+              method_of_diagnosis:
+                type: keyword
               morphology:
+                type: keyword
+              new_event_anatomic_site:
+                type: keyword
+              new_event_type:
+                type: keyword
+              perineural_invasion_present:
                 type: keyword
               primary_diagnosis:
                 type: keyword
               prior_malignancy:
                 type: keyword
+              prior_treatment:
+                type: keyword
               progression_or_recurrence:
+                type: keyword
+              residual_disease:
                 type: keyword
               site_of_resection_or_biopsy:
                 type: keyword
@@ -199,9 +271,10 @@ properties:
               tissue_or_organ_of_origin:
                 type: keyword
               treatments:
+                type: nested
                 properties:
                   created_datetime:
-                    type: keyword
+                    type: date
                   days_to_treatment:
                     type: long
                   days_to_treatment_end:
@@ -234,23 +307,42 @@ properties:
                 type: keyword
               updated_datetime:
                 type: date
+              vascular_invasion_present:
+                type: keyword
               vital_status:
                 type: keyword
+              year_of_diagnosis:
+                type: long
           disease_type:
             type: keyword
           exposures:
+            type: nested
             properties:
+              alcohol_history:
+                type: keyword
+              alcohol_intensity:
+                type: keyword
               bmi:
                 type: float
               cigarettes_per_day:
                 type: float
+              created_datetime:
+                type: date
               exposure_id:
                 type: keyword
               height:
                 type: float
+              pack_years_smoked:
+                type: long
               state:
                 type: keyword
               submitter_id:
+                type: keyword
+              tobacco_smoking_onset_year:
+                type: long
+              tobacco_smoking_quit_year:
+                type: long
+              tobacco_smoking_status:
                 type: keyword
               updated_datetime:
                 type: date
@@ -317,11 +409,38 @@ properties:
                     type: keyword
                   variant_process:
                     type: keyword
+          family_histories:
+            type: nested
+            properties:
+              created_datetime:
+                type: date
+              family_history_id:
+                type: keyword
+              relationship_age_at_diagnosis:
+                type: long
+              relationship_gender:
+                type: keyword
+              relationship_primary_diagnosis:
+                type: keyword
+              relationship_type:
+                type: keyword
+              relative_with_cancer_history:
+                type: keyword
+              state:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: date
           primary_site:
             type: keyword
           project:
             properties:
+              dbgap_accession_number:
+                type: keyword
               disease_type:
+                type: keyword
+              intended_release_date:
                 type: keyword
               name:
                 type: keyword
@@ -336,6 +455,8 @@ properties:
                   program_id:
                     type: keyword
               project_id:
+                type: keyword
+              releasable:
                 type: keyword
               released:
                 type: boolean
@@ -355,6 +476,7 @@ properties:
                   file_count:
                     type: long
               experimental_strategies:
+                type: nested
                 properties:
                   experimental_strategy:
                     type: keyword

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -6,11 +6,13 @@ properties:
       case_id:
         type: keyword
       created_datetime:
-        type: keyword
+        type: date
+      days_to_index:
+        type: long
       demographic:
         properties:
           created_datetime:
-            type: keyword
+            type: date
           demographic_id:
             type: keyword
           ethnicity:
@@ -34,27 +36,97 @@ properties:
         properties:
           age_at_diagnosis:
             type: long
+          ajcc_clinical_m:
+            type: keyword
+          ajcc_clinical_n:
+            type: keyword
+          ajcc_clinical_stage:
+            type: keyword
+          ajcc_clinical_t:
+            type: keyword
+          ajcc_pathologic_m:
+            type: keyword
+          ajcc_pathologic_n:
+            type: keyword
+          ajcc_pathologic_stage:
+            type: keyword
+          ajcc_pathologic_t:
+            type: keyword
+          ann_arbor_b_symptoms:
+            type: keyword
+          ann_arbor_clinical_stage:
+            type: keyword
+          ann_arbor_extranodal_involvement:
+            type: keyword
+          ann_arbor_pathologic_stage:
+            type: keyword
+          burkitt_lymphoma_clinical_variant:
+            type: keyword
+          cause_of_death:
+            type: keyword
+          circumferential_resection_margin:
+            type: long
           classification_of_tumor:
             type: keyword
-          created_datetime:
+          colon_polyps_history:
             type: keyword
+          created_datetime:
+            type: date
           days_to_birth:
             type: long
           days_to_death:
             type: long
+          days_to_hiv_diagnosis:
+            type: long
           days_to_last_follow_up:
+            type: long
+          days_to_last_known_disease_status:
+            type: long
+          days_to_new_event:
+            type: long
+          days_to_recurrence:
             type: long
           diagnosis_id:
             type: keyword
+          figo_stage:
+            type: keyword
+          hiv_positive:
+            type: keyword
+          hpv_positive_type:
+            type: keyword
+          hpv_status:
+            type: keyword
           last_known_disease_status:
             type: keyword
+          laterality:
+            type: keyword
+          ldh_level_at_diagnosis:
+            type: long
+          ldh_normal_range_upper:
+            type: long
+          lymph_nodes_positive:
+            type: long
+          lymphatic_invasion_present:
+            type: keyword
+          method_of_diagnosis:
+            type: keyword
           morphology:
+            type: keyword
+          new_event_anatomic_site:
+            type: keyword
+          new_event_type:
+            type: keyword
+          perineural_invasion_present:
             type: keyword
           primary_diagnosis:
             type: keyword
           prior_malignancy:
             type: keyword
+          prior_treatment:
+            type: keyword
           progression_or_recurrence:
+            type: keyword
+          residual_disease:
             type: keyword
           site_of_resection_or_biopsy:
             type: keyword
@@ -65,9 +137,10 @@ properties:
           tissue_or_organ_of_origin:
             type: keyword
           treatments:
+            type: nested
             properties:
               created_datetime:
-                type: keyword
+                type: date
               days_to_treatment:
                 type: long
               days_to_treatment_end:
@@ -100,23 +173,42 @@ properties:
             type: keyword
           updated_datetime:
             type: date
+          vascular_invasion_present:
+            type: keyword
           vital_status:
             type: keyword
+          year_of_diagnosis:
+            type: long
       disease_type:
         type: keyword
       exposures:
+        type: nested
         properties:
+          alcohol_history:
+            type: keyword
+          alcohol_intensity:
+            type: keyword
           bmi:
             type: float
           cigarettes_per_day:
             type: float
+          created_datetime:
+            type: date
           exposure_id:
             type: keyword
           height:
             type: float
+          pack_years_smoked:
+            type: long
           state:
             type: keyword
           submitter_id:
+            type: keyword
+          tobacco_smoking_onset_year:
+            type: long
+          tobacco_smoking_quit_year:
+            type: long
+          tobacco_smoking_status:
             type: keyword
           updated_datetime:
             type: date
@@ -183,11 +275,38 @@ properties:
                 type: keyword
               variant_process:
                 type: keyword
+      family_histories:
+        type: nested
+        properties:
+          created_datetime:
+            type: date
+          family_history_id:
+            type: keyword
+          relationship_age_at_diagnosis:
+            type: long
+          relationship_gender:
+            type: keyword
+          relationship_primary_diagnosis:
+            type: keyword
+          relationship_type:
+            type: keyword
+          relative_with_cancer_history:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: date
       primary_site:
         type: keyword
       project:
         properties:
+          dbgap_accession_number:
+            type: keyword
           disease_type:
+            type: keyword
+          intended_release_date:
             type: keyword
           name:
             type: keyword
@@ -202,6 +321,8 @@ properties:
               program_id:
                 type: keyword
           project_id:
+            type: keyword
+          releasable:
             type: keyword
           released:
             type: boolean
@@ -221,6 +342,7 @@ properties:
               file_count:
                 type: long
           experimental_strategies:
+            type: nested
             properties:
               experimental_strategy:
                 type: keyword


### PR DESCRIPTION
This PR add the missing fields of case to all 4 centric indices. It will solve both issue #17 and #18 . 
The mapping files have been used by indices loading with `Dynamic=strict` and they all work. 