### PR TITLE
Id fields consistency

### DIFF
--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -298,6 +298,8 @@ properties:
           consequence:
             type: nested
             properties:
+              consequence_id:
+                type: keyword
               transcript:
                 properties:
                   aa_change:

--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -392,7 +392,11 @@ properties:
               mutation_status:
                 type: keyword
               normal_genotype:
-                type: object
+                properties:
+                  match_norm_seq_allele2:
+                    type: keyword
+                  match_norm_seq_allele1:
+                    type: keyword
               read_depth:
                 properties:
                   n_depth:

--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -377,6 +377,8 @@ properties:
           observation:
             type: nested
             properties:
+              observation_id:
+                type: keyword
               center:
                 type: keyword
               input_bam_file:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -369,6 +369,8 @@ properties:
           observation:
             type: nested
             properties:
+              observation_id:
+                type: keyword
               center:
                 type: keyword
               input_bam_file:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -290,6 +290,8 @@ properties:
           consequence:
             type: nested
             properties:
+              consequence_id:
+                type: keyword
               transcript:
                 properties:
                   aa_change:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -384,7 +384,11 @@ properties:
               mutation_status:
                 type: keyword
               normal_genotype:
-                type: object
+                properties:
+                  match_norm_seq_allele2:
+                    type: keyword
+                  match_norm_seq_allele1:
+                    type: keyword
               read_depth:
                 properties:
                   n_depth:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -367,7 +367,6 @@ properties:
                     type: keyword
                   match_norm_seq_allele1:
                     type: keyword
-
               observation_id:
                 type: keyword
               read_depth:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -362,7 +362,12 @@ properties:
               mutation_status:
                 type: keyword
               normal_genotype:
-                type: object
+                properties:
+                  match_norm_seq_allele2:
+                    type: keyword
+                  match_norm_seq_allele1:
+                    type: keyword
+
               observation_id:
                 type: keyword
               read_depth:

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -230,7 +230,11 @@ properties:
           mutation_status:
             type: keyword
           normal_genotype:
-            type: object
+            properties:
+              match_norm_seq_allele2:
+                type: keyword
+              match_norm_seq_allele1:
+                type: keyword
           observation_id:
             type: keyword
           read_depth:


### PR DESCRIPTION
- Add `observation_id` and `consequence_id` to all indices for consistency
- Fixed `normal_genotype` mapping