### PR TITLE
fix(timeout) Increase default timeout to 60s

### DIFF
--- a/init_index.py
+++ b/init_index.py
@@ -30,7 +30,8 @@ def init_index():
     es_models = get_es_models()
 
     es = Elasticsearch(hosts="%s:%s" % (args.host, args.port),
-                        http_auth=(args.user, args.password))
+                        http_auth=(args.user, args.password),
+                        timeout=60)
 
     for i in args.index:
         if not es_models.get(i):


### PR DESCRIPTION
I ran this script against our `release` testing ES cluster and the default 10s timeout was just barely not enough. 60s seems like a reasonable next step up. 