### PR TITLE
fix(mapping): Add mappings for graphql subm to pick up new fields

### DIFF
--- a/es-models/gdc_from_graph/annotation.mapping.yaml
+++ b/es-models/gdc_from_graph/annotation.mapping.yaml
@@ -17,6 +17,8 @@ properties:
     copy_to:
     - annotation_autocomplete
     type: keyword
+  batch_id:
+    type: long
   case_id:
     type: keyword
   case_submitter_id:

--- a/es-models/gdc_from_graph/case.mapping.yaml
+++ b/es-models/gdc_from_graph/case.mapping.yaml
@@ -82,6 +82,8 @@ properties:
         type: keyword
       gender:
         type: keyword
+      premature_at_birth:
+        type: keyword
       race:
         type: keyword
       state:
@@ -92,6 +94,8 @@ properties:
         type: keyword
       vital_status:
         type: keyword
+      weeks_gestation_at_birth:
+        type: long
       year_of_birth:
         type: long
       year_of_death:
@@ -266,6 +270,10 @@ properties:
     type: keyword
   exposures:
     properties:
+      alcohol_days_per_week:
+        type: long
+      alcohol_drinks_per_day:
+        type: long
       alcohol_history:
         type: keyword
       alcohol_intensity:
@@ -519,6 +527,8 @@ properties:
                   target_capture_kit_vendor:
                     type: keyword
                   target_capture_kit_version:
+                    type: keyword
+                  target_capture_kit:
                     type: keyword
                   to_trim_adapter_sequence:
                     type: keyword
@@ -788,11 +798,17 @@ properties:
     type: keyword
   project:
     properties:
+      awg_review:
+        type: keyword
       dbgap_accession_number:
         type: keyword
       disease_type:
         type: keyword
       intended_release_date:
+        type: keyword
+      in_review:
+        type: keyword
+      is_legacy:
         type: keyword
       name:
         type: keyword
@@ -812,7 +828,13 @@ properties:
         type: keyword
       released:
         type: keyword
+      release_requested:
+        type: keyword
+      request_submission:
+        type: keyword
       state:
+        type: keyword
+      submission_enabled:
         type: keyword
   sample_ids:
     type: keyword
@@ -822,9 +844,13 @@ properties:
         properties:
           annotation_id:
             type: keyword
+          biospecimen_laterality:
+            type: keyword
           case_id:
             type: keyword
           case_submitter_id:
+            type: keyword
+          catalog_reference:
             type: keyword
           category:
             type: keyword
@@ -834,18 +860,26 @@ properties:
             type: keyword
           creator:
             type: keyword
+          distance_normal_to_tumor:
+            type: keyword
+          distributor_reference:
+            type: keyword
           entity_id:
             type: keyword
           entity_submitter_id:
             type: keyword
           entity_type:
             type: keyword
+          growth_rate:
+            type: long
           legacy_created_datetime:
             type: keyword
           legacy_updated_datetime:
             type: keyword
           notes:
             type: keyword
+          passage_count:
+            type: long
           state:
             type: keyword
           status:

--- a/es-models/gdc_from_graph/case.mapping.yaml
+++ b/es-models/gdc_from_graph/case.mapping.yaml
@@ -540,6 +540,8 @@ properties:
                     type: keyword
                   submitter_id:
                     type: keyword
+                  target_capture_kit:
+                    type: keyword
                   target_capture_kit_catalog_number:
                     type: keyword
                   target_capture_kit_name:
@@ -549,8 +551,6 @@ properties:
                   target_capture_kit_vendor:
                     type: keyword
                   target_capture_kit_version:
-                    type: keyword
-                  target_capture_kit:
                     type: keyword
                   to_trim_adapter_sequence:
                     type: keyword
@@ -607,6 +607,8 @@ properties:
             type: keyword
           updated_datetime:
             type: keyword
+      batch_id:
+        type: long
       center:
         properties:
           center_id:
@@ -621,8 +623,6 @@ properties:
             type: keyword
           short_name:
             type: keyword
-      batch_id:
-        type: long
       created_datetime:
         type: keyword
       data_category:
@@ -838,9 +838,9 @@ properties:
         type: keyword
       disease_type:
         type: keyword
-      intended_release_date:
-        type: keyword
       in_review:
+        type: keyword
+      intended_release_date:
         type: keyword
       is_legacy:
         type: keyword
@@ -860,9 +860,9 @@ properties:
         type: keyword
       releasable:
         type: keyword
-      released:
-        type: keyword
       release_requested:
+        type: keyword
+      released:
         type: keyword
       request_submission:
         type: keyword
@@ -1018,6 +1018,8 @@ properties:
                       updated_datetime:
                         type: keyword
                     type: nested
+                  batch_id:
+                    type: long
                   center:
                     properties:
                       center_id:
@@ -1032,8 +1034,6 @@ properties:
                         type: keyword
                       short_name:
                         type: keyword
-                  batch_id:
-                    type: long
                   concentration:
                     type: long
                   created_datetime:

--- a/es-models/gdc_from_graph/case.mapping.yaml
+++ b/es-models/gdc_from_graph/case.mapping.yaml
@@ -7,6 +7,8 @@ properties:
     properties:
       annotation_id:
         type: keyword
+      batch_id:
+        type: long
       case_id:
         type: keyword
       case_submitter_id:
@@ -40,6 +42,8 @@ properties:
       updated_datetime:
         type: keyword
     type: nested
+  batch_id:
+    type: long
   case_autocomplete:
     fields:
       analyzed:
@@ -67,6 +71,8 @@ properties:
   demographic:
     properties:
       age_at_index:
+        type: long
+      batch_id:
         type: long
       cause_of_death:
         type: keyword
@@ -128,6 +134,8 @@ properties:
         type: keyword
       ann_arbor_pathologic_stage:
         type: keyword
+      batch_id:
+        type: long
       best_overall_response:
         type: keyword
       burkitt_lymphoma_clinical_variant:
@@ -220,6 +228,8 @@ properties:
         type: keyword
       treatments:
         properties:
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           days_to_treatment:
@@ -278,6 +288,8 @@ properties:
         type: keyword
       alcohol_intensity:
         type: keyword
+      batch_id:
+        type: long
       bmi:
         type: long
       cigarettes_per_day:
@@ -309,6 +321,8 @@ properties:
     type: nested
   family_histories:
     properties:
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       family_history_id:
@@ -342,12 +356,16 @@ properties:
             type: keyword
           analysis_type:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           input_files:
             properties:
               access:
                 type: keyword
+              batch_id:
+                type: long
               created_datetime:
                 type: keyword
               data_category:
@@ -401,6 +419,8 @@ properties:
                     type: keyword
                   base_caller_version:
                     type: keyword
+                  batch_id:
+                    type: long
                   created_datetime:
                     type: keyword
                   experiment_name:
@@ -453,6 +473,8 @@ properties:
                         type: keyword
                       basic_statistics:
                         type: keyword
+                      batch_id:
+                        type: long
                       created_datetime:
                         type: keyword
                       encoding:
@@ -555,6 +577,8 @@ properties:
         properties:
           archive_id:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           data_category:
@@ -597,6 +621,8 @@ properties:
             type: keyword
           short_name:
             type: keyword
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       data_category:
@@ -611,12 +637,16 @@ properties:
             type: keyword
           analysis_type:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           output_files:
             properties:
               access:
                 type: keyword
+              batch_id:
+                type: long
               created_datetime:
                 type: keyword
               data_category:
@@ -691,6 +721,8 @@ properties:
         properties:
           access:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           data_category:
@@ -738,6 +770,8 @@ properties:
         properties:
           access:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           data_category:
@@ -844,6 +878,8 @@ properties:
         properties:
           annotation_id:
             type: keyword
+          batch_id:
+            type: long
           biospecimen_laterality:
             type: keyword
           case_id:
@@ -889,6 +925,8 @@ properties:
           updated_datetime:
             type: keyword
         type: nested
+      batch_id:
+        type: long
       biospecimen_anatomic_site:
         type: keyword
       composition:
@@ -945,6 +983,8 @@ properties:
                     properties:
                       annotation_id:
                         type: keyword
+                      batch_id:
+                        type: long
                       case_id:
                         type: keyword
                       case_submitter_id:
@@ -992,6 +1032,8 @@ properties:
                         type: keyword
                       short_name:
                         type: keyword
+                  batch_id:
+                    type: long
                   concentration:
                     type: long
                   created_datetime:
@@ -1025,6 +1067,8 @@ properties:
                 properties:
                   annotation_id:
                     type: keyword
+                  batch_id:
+                    type: long
                   case_id:
                     type: keyword
                   case_submitter_id:
@@ -1058,6 +1102,8 @@ properties:
                   updated_datetime:
                     type: keyword
                 type: nested
+              batch_id:
+                type: long
               concentration:
                 type: long
               created_datetime:
@@ -1083,6 +1129,8 @@ properties:
             properties:
               annotation_id:
                 type: keyword
+              batch_id:
+                type: long
               case_id:
                 type: keyword
               case_submitter_id:
@@ -1116,6 +1164,8 @@ properties:
               updated_datetime:
                 type: keyword
             type: nested
+          batch_id:
+            type: long
           center:
             properties:
               center_id:
@@ -1148,6 +1198,8 @@ properties:
                 properties:
                   annotation_id:
                     type: keyword
+                  batch_id:
+                    type: long
                   case_id:
                     type: keyword
                   case_submitter_id:
@@ -1181,6 +1233,8 @@ properties:
                   updated_datetime:
                     type: keyword
                 type: nested
+              batch_id:
+                type: long
               created_datetime:
                 type: keyword
               number_proliferating_cells:

--- a/es-models/gdc_from_graph/file.mapping.yaml
+++ b/es-models/gdc_from_graph/file.mapping.yaml
@@ -9,12 +9,16 @@ properties:
         type: keyword
       analysis_type:
         type: keyword
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       input_files:
         properties:
           access:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           data_category:
@@ -68,6 +72,8 @@ properties:
                 type: keyword
               base_caller_version:
                 type: keyword
+              batch_id:
+                type: long
               created_datetime:
                 type: keyword
               experiment_name:
@@ -120,6 +126,8 @@ properties:
                     type: keyword
                   basic_statistics:
                     type: keyword
+                  batch_id:
+                    type: long
                   created_datetime:
                     type: keyword
                   encoding:
@@ -222,6 +230,8 @@ properties:
     properties:
       annotation_id:
         type: keyword
+      batch_id:
+        type: long
       case_id:
         type: keyword
       case_submitter_id:
@@ -259,6 +269,8 @@ properties:
     properties:
       archive_id:
         type: keyword
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       data_category:
@@ -308,6 +320,8 @@ properties:
         properties:
           annotation_id:
             type: keyword
+          batch_id:
+            type: long
           case_id:
             type: keyword
           case_submitter_id:
@@ -341,6 +355,8 @@ properties:
           updated_datetime:
             type: keyword
         type: nested
+      batch_id:
+        type: long
       case_id:
         type: keyword
       created_datetime:
@@ -352,6 +368,8 @@ properties:
       demographic:
         properties:
           age_at_index:
+            type: long
+          batch_id:
             type: long
           cause_of_death:
             type: keyword
@@ -413,6 +431,8 @@ properties:
             type: keyword
           ann_arbor_pathologic_stage:
             type: keyword
+          batch_id:
+            type: long
           best_overall_response:
             type: keyword
           burkitt_lymphoma_clinical_variant:
@@ -505,6 +525,8 @@ properties:
             type: keyword
           treatments:
             properties:
+              batch_id:
+                type: long
               created_datetime:
                 type: keyword
               days_to_treatment:
@@ -563,6 +585,8 @@ properties:
             type: keyword
           alcohol_intensity:
             type: keyword
+          batch_id:
+            type: long
           bmi:
             type: long
           cigarettes_per_day:
@@ -594,6 +618,8 @@ properties:
         type: nested
       family_histories:
         properties:
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           family_history_id:
@@ -671,6 +697,8 @@ properties:
             properties:
               annotation_id:
                 type: keyword
+              batch_id:
+                type: long
               biospecimen_laterality:
                 type: keyword
               case_id:
@@ -716,6 +744,8 @@ properties:
               updated_datetime:
                 type: keyword
             type: nested
+          batch_id:
+            type: long
           biospecimen_anatomic_site:
             type: keyword
           composition:
@@ -770,6 +800,8 @@ properties:
                         properties:
                           annotation_id:
                             type: keyword
+                          batch_id:
+                            type: long
                           case_id:
                             type: keyword
                           case_submitter_id:
@@ -803,6 +835,8 @@ properties:
                           updated_datetime:
                             type: keyword
                         type: nested
+                      batch_id:
+                        type: long
                       center:
                         properties:
                           center_id:
@@ -846,6 +880,8 @@ properties:
                     properties:
                       annotation_id:
                         type: keyword
+                      batch_id:
+                        type: long
                       case_id:
                         type: keyword
                       case_submitter_id:
@@ -879,6 +915,8 @@ properties:
                       updated_datetime:
                         type: keyword
                     type: nested
+                  batch_id:
+                    type: long
                   concentration:
                     type: long
                   created_datetime:
@@ -902,6 +940,8 @@ properties:
                 properties:
                   annotation_id:
                     type: keyword
+                  batch_id:
+                    type: long
                   case_id:
                     type: keyword
                   case_submitter_id:
@@ -949,6 +989,8 @@ properties:
                     type: keyword
                   short_name:
                     type: keyword
+              batch_id:
+                type: long
               created_datetime:
                 type: keyword
               creation_datetime:
@@ -965,6 +1007,8 @@ properties:
                     properties:
                       annotation_id:
                         type: keyword
+                      batch_id:
+                        type: long
                       case_id:
                         type: keyword
                       case_submitter_id:
@@ -998,6 +1042,8 @@ properties:
                       updated_datetime:
                         type: keyword
                     type: nested
+                  batch_id:
+                    type: long
                   created_datetime:
                     type: keyword
                   number_proliferating_cells:
@@ -1138,6 +1184,8 @@ properties:
         type: keyword
       short_name:
         type: keyword
+  batch_id:
+    type: long
   created_datetime:
     type: keyword
   data_category:
@@ -1156,12 +1204,16 @@ properties:
         type: keyword
       analysis_type:
         type: keyword
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       output_files:
         properties:
           access:
             type: keyword
+          batch_id:
+            type: long
           created_datetime:
             type: keyword
           data_category:
@@ -1256,6 +1308,8 @@ properties:
     properties:
       access:
         type: keyword
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       data_category:
@@ -1305,6 +1359,8 @@ properties:
     properties:
       access:
         type: keyword
+      batch_id:
+        type: long
       created_datetime:
         type: keyword
       data_category:

--- a/es-models/gdc_from_graph/file.mapping.yaml
+++ b/es-models/gdc_from_graph/file.mapping.yaml
@@ -195,6 +195,8 @@ properties:
                 type: keyword
               target_capture_kit_version:
                 type: keyword
+              target_capture_kit:
+                type: keyword
               to_trim_adapter_sequence:
                 type: keyword
               updated_datetime:
@@ -365,6 +367,8 @@ properties:
             type: keyword
           gender:
             type: keyword
+          premature_at_birth:
+            type: keyword
           race:
             type: keyword
           state:
@@ -375,6 +379,8 @@ properties:
             type: keyword
           vital_status:
             type: keyword
+          weeks_gestation_at_birth:
+            type: long
           year_of_birth:
             type: long
           year_of_death:
@@ -549,6 +555,10 @@ properties:
         type: keyword
       exposures:
         properties:
+          alcohol_days_per_week:
+            type: long
+          alcohol_drinks_per_day:
+            type: long
           alcohol_history:
             type: keyword
           alcohol_intensity:
@@ -615,11 +625,17 @@ properties:
         type: keyword
       project:
         properties:
+          awg_review:
+            type: keyword
           dbgap_accession_number:
             type: keyword
           disease_type:
             type: keyword
           intended_release_date:
+            type: keyword
+          in_review:
+            type: keyword
+          is_legacy:
             type: keyword
           name:
             type: keyword
@@ -639,7 +655,13 @@ properties:
             type: keyword
           released:
             type: keyword
+          release_requested:
+            type: keyword
+          request_submission:
+            type: keyword
           state:
+            type: keyword
+          submission_enabled:
             type: keyword
       sample_ids:
         type: keyword
@@ -649,9 +671,13 @@ properties:
             properties:
               annotation_id:
                 type: keyword
+              biospecimen_laterality:
+                type: keyword
               case_id:
                 type: keyword
               case_submitter_id:
+                type: keyword
+              catalog_reference:
                 type: keyword
               category:
                 type: keyword
@@ -661,18 +687,26 @@ properties:
                 type: keyword
               creator:
                 type: keyword
+              distance_normal_to_tumor:
+                type: keyword
+              distributor_reference:
+                type: keyword
               entity_id:
                 type: keyword
               entity_submitter_id:
                 type: keyword
               entity_type:
                 type: keyword
+              growth_rate:
+                type: long
               legacy_created_datetime:
                 type: keyword
               legacy_updated_datetime:
                 type: keyword
               notes:
                 type: keyword
+              passage_count:
+                type: long
               state:
                 type: keyword
               status:

--- a/es-models/gdc_from_graph/file.mapping.yaml
+++ b/es-models/gdc_from_graph/file.mapping.yaml
@@ -193,6 +193,8 @@ properties:
                 type: keyword
               submitter_id:
                 type: keyword
+              target_capture_kit:
+                type: keyword
               target_capture_kit_catalog_number:
                 type: keyword
               target_capture_kit_name:
@@ -202,8 +204,6 @@ properties:
               target_capture_kit_vendor:
                 type: keyword
               target_capture_kit_version:
-                type: keyword
-              target_capture_kit:
                 type: keyword
               to_trim_adapter_sequence:
                 type: keyword
@@ -310,6 +310,8 @@ properties:
       entity_type:
         type: keyword
     type: nested
+  batch_id:
+    type: long
   cases:
     properties:
       aliquot_ids:
@@ -657,9 +659,9 @@ properties:
             type: keyword
           disease_type:
             type: keyword
-          intended_release_date:
-            type: keyword
           in_review:
+            type: keyword
+          intended_release_date:
             type: keyword
           is_legacy:
             type: keyword
@@ -679,9 +681,9 @@ properties:
             type: keyword
           releasable:
             type: keyword
-          released:
-            type: keyword
           release_requested:
+            type: keyword
+          released:
             type: keyword
           request_submission:
             type: keyword
@@ -975,6 +977,8 @@ properties:
                   updated_datetime:
                     type: keyword
                 type: nested
+              batch_id:
+                type: long
               center:
                 properties:
                   center_id:
@@ -989,8 +993,6 @@ properties:
                     type: keyword
                   short_name:
                     type: keyword
-              batch_id:
-                type: long
               created_datetime:
                 type: keyword
               creation_datetime:
@@ -1184,8 +1186,6 @@ properties:
         type: keyword
       short_name:
         type: keyword
-  batch_id:
-    type: long
   created_datetime:
     type: keyword
   data_category:


### PR DESCRIPTION
- Add mappings so that graphql submission endpoint will properly
pick up & display the new fields we added, changes were only
made to the gdc_from_graph mappings, as those are the ones
that the submission graphql endpoint uses. Once we have data and
want these in esbuild, we'll have to update from that mapping