### PR TITLE
fix(missing-gc-fields): add fields to gene_centric

### DIFF
--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -73,6 +73,10 @@ properties:
           start_position:
             type: long
         type: nested
+      created_datetime:
+        type: date
+      days_to_index:
+        type: long
       demographic:
         properties:
           created_datetime:


### PR DESCRIPTION
Add `created_datetime` and `days_to_index` to the `case` definition in gene_centric, to match the other indices. This fixes issues with indexing cases that contain either of those fields.