### PR TITLE
feat(legacy-mappings): check-in legacy mappings

### DIFF
--- a/es-models/gdc_legacy_graph/annotation.mapping.yaml
+++ b/es-models/gdc_legacy_graph/annotation.mapping.yaml
@@ -1,0 +1,63 @@
+properties:
+  annotation_id:
+    type: keyword
+  case_id:
+    type: keyword
+  case_submitter_id:
+    type: keyword
+  category:
+    type: keyword
+  classification:
+    type: keyword
+  created_datetime:
+    type: keyword
+  entity_id:
+    type: keyword
+  entity_submitter_id:
+    type: keyword
+  entity_type:
+    type: keyword
+  legacy_created_datetime:
+    type: keyword
+  legacy_updated_datetime:
+    type: keyword
+  notes:
+    type: keyword
+  project:
+    properties:
+      code:
+        type: keyword
+      dbgap_accession_number:
+        type: keyword
+      disease_type:
+        type: keyword
+      intended_release_date:
+        type: keyword
+      name:
+        type: keyword
+      primary_site:
+        type: keyword
+      program:
+        properties:
+          dbgap_accession_number:
+            type: keyword
+          name:
+            type: keyword
+          program_id:
+            type: keyword
+      project_id:
+        type: keyword
+      releasable:
+        type: keyword
+      released:
+        type: keyword
+      state:
+        type: keyword
+  state:
+    type: keyword
+  status:
+    type: keyword
+  submitter_id:
+    type: keyword
+  updated_datetime:
+    type: keyword

--- a/es-models/gdc_legacy_graph/case.mapping.yaml
+++ b/es-models/gdc_legacy_graph/case.mapping.yaml
@@ -1,0 +1,1254 @@
+properties:
+  aliquot_ids:
+    type: keyword
+  analyte_ids:
+    type: keyword
+  annotations:
+    properties:
+      annotation_id:
+        type: keyword
+      case_id:
+        type: keyword
+      case_submitter_id:
+        type: keyword
+      category:
+        type: keyword
+      classification:
+        type: keyword
+      created_datetime:
+        type: keyword
+      creator:
+        type: keyword
+      entity_id:
+        type: keyword
+      entity_submitter_id:
+        type: keyword
+      entity_type:
+        type: keyword
+      legacy_created_datetime:
+        type: keyword
+      legacy_updated_datetime:
+        type: keyword
+      notes:
+        type: keyword
+      state:
+        type: keyword
+      status:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  case_id:
+    type: keyword
+  created_datetime:
+    type: keyword
+  days_to_index:
+    type: long
+  days_to_lost_to_followup:
+    type: long
+  demographic:
+    properties:
+      age_at_index:
+        type: long
+      cause_of_death:
+        type: keyword
+      created_datetime:
+        type: keyword
+      days_to_birth:
+        type: long
+      days_to_death:
+        type: long
+      demographic_id:
+        type: keyword
+      ethnicity:
+        type: keyword
+      gender:
+        type: keyword
+      premature_at_birth:
+        type: keyword
+      race:
+        type: keyword
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+      vital_status:
+        type: keyword
+      weeks_gestation_at_birth:
+        type: long
+      year_of_birth:
+        type: long
+      year_of_death:
+        type: long
+  diagnoses:
+    properties:
+      age_at_diagnosis:
+        type: long
+      ajcc_clinical_m:
+        type: keyword
+      ajcc_clinical_n:
+        type: keyword
+      ajcc_clinical_stage:
+        type: keyword
+      ajcc_clinical_t:
+        type: keyword
+      ajcc_pathologic_m:
+        type: keyword
+      ajcc_pathologic_n:
+        type: keyword
+      ajcc_pathologic_stage:
+        type: keyword
+      ajcc_pathologic_t:
+        type: keyword
+      ajcc_staging_system_edition:
+        type: keyword
+      anaplasia_present:
+        type: keyword
+      anaplasia_present_type:
+        type: keyword
+      ann_arbor_b_symptoms:
+        type: keyword
+      ann_arbor_clinical_stage:
+        type: keyword
+      ann_arbor_extranodal_involvement:
+        type: keyword
+      ann_arbor_pathologic_stage:
+        type: keyword
+      annotations:
+        properties:
+          annotation_id:
+            type: keyword
+          case_id:
+            type: keyword
+          case_submitter_id:
+            type: keyword
+          category:
+            type: keyword
+          classification:
+            type: keyword
+          created_datetime:
+            type: keyword
+          creator:
+            type: keyword
+          entity_id:
+            type: keyword
+          entity_submitter_id:
+            type: keyword
+          entity_type:
+            type: keyword
+          legacy_created_datetime:
+            type: keyword
+          legacy_updated_datetime:
+            type: keyword
+          notes:
+            type: keyword
+          state:
+            type: keyword
+          status:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      best_overall_response:
+        type: keyword
+      burkitt_lymphoma_clinical_variant:
+        type: keyword
+      child_pugh_classification:
+        type: keyword
+      circumferential_resection_margin:
+        type: long
+      classification_of_tumor:
+        type: keyword
+      cog_liver_stage:
+        type: keyword
+      cog_neuroblastoma_risk_group:
+        type: keyword
+      cog_renal_stage:
+        type: keyword
+      cog_rhabdomyosarcoma_risk_group:
+        type: keyword
+      created_datetime:
+        type: keyword
+      days_to_best_overall_response:
+        type: long
+      days_to_diagnosis:
+        type: long
+      days_to_last_follow_up:
+        type: long
+      days_to_last_known_disease_status:
+        type: long
+      days_to_recurrence:
+        type: long
+      diagnosis_id:
+        type: keyword
+      enneking_msts_grade:
+        type: keyword
+      enneking_msts_metastasis:
+        type: keyword
+      enneking_msts_stage:
+        type: keyword
+      enneking_msts_tumor_site:
+        type: keyword
+      esophageal_columnar_dysplasia_degree:
+        type: keyword
+      esophageal_columnar_metaplasia_present:
+        type: keyword
+      figo_stage:
+        type: keyword
+      first_symptom_prior_to_diagnosis:
+        type: keyword
+      gastric_esophageal_junction_involvement:
+        type: keyword
+      gleason_grade_group:
+        type: keyword
+      goblet_cells_columnar_mucosa_present:
+        type: keyword
+      gross_tumor_weight:
+        type: long
+      icd_10_code:
+        type: keyword
+      igcccg_stage:
+        type: keyword
+      inpc_grade:
+        type: keyword
+      inpc_histologic_group:
+        type: keyword
+      inrg_stage:
+        type: keyword
+      inss_stage:
+        type: keyword
+      irs_group:
+        type: keyword
+      irs_stage:
+        type: keyword
+      ishak_fibrosis_score:
+        type: keyword
+      iss_stage:
+        type: keyword
+      last_known_disease_status:
+        type: keyword
+      laterality:
+        type: keyword
+      lymph_nodes_positive:
+        type: long
+      lymph_nodes_tested:
+        type: long
+      lymphatic_invasion_present:
+        type: keyword
+      masaoka_stage:
+        type: keyword
+      medulloblastoma_molecular_classification:
+        type: keyword
+      metastasis_at_diagnosis:
+        type: keyword
+      metastasis_at_diagnosis_site:
+        type: keyword
+      method_of_diagnosis:
+        type: keyword
+      micropapillary_features:
+        type: keyword
+      mitosis_karyorrhexis_index:
+        type: keyword
+      morphology:
+        type: keyword
+      perineural_invasion_present:
+        type: keyword
+      peripancreatic_lymph_nodes_positive:
+        type: keyword
+      peripancreatic_lymph_nodes_tested:
+        type: long
+      primary_diagnosis:
+        type: keyword
+      primary_gleason_grade:
+        type: keyword
+      prior_malignancy:
+        type: keyword
+      prior_treatment:
+        type: keyword
+      progression_or_recurrence:
+        type: keyword
+      residual_disease:
+        type: keyword
+      secondary_gleason_grade:
+        type: keyword
+      site_of_resection_or_biopsy:
+        type: keyword
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      supratentorial_localization:
+        type: keyword
+      synchronous_malignancy:
+        type: keyword
+      tissue_or_organ_of_origin:
+        type: keyword
+      treatments:
+        properties:
+          created_datetime:
+            type: keyword
+          days_to_treatment_end:
+            type: long
+          days_to_treatment_start:
+            type: long
+          initial_disease_status:
+            type: keyword
+          regimen_or_line_of_therapy:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          therapeutic_agents:
+            type: keyword
+          treatment_anatomic_site:
+            type: keyword
+          treatment_effect:
+            type: keyword
+          treatment_id:
+            type: keyword
+          treatment_intent_type:
+            type: keyword
+          treatment_or_therapy:
+            type: keyword
+          treatment_outcome:
+            type: keyword
+          treatment_type:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      tumor_confined_to_organ_of_origin:
+        type: keyword
+      tumor_focality:
+        type: keyword
+      tumor_grade:
+        type: keyword
+      tumor_largest_dimension_diameter:
+        type: long
+      tumor_regression_grade:
+        type: keyword
+      tumor_stage:
+        type: keyword
+      updated_datetime:
+        type: keyword
+      vascular_invasion_present:
+        type: keyword
+      vascular_invasion_type:
+        type: keyword
+      weiss_assessment_score:
+        type: keyword
+      wilms_tumor_histologic_subtype:
+        type: keyword
+      year_of_diagnosis:
+        type: long
+    type: nested
+  diagnosis_ids:
+    type: keyword
+  disease_type:
+    type: keyword
+  exposures:
+    properties:
+      alcohol_days_per_week:
+        type: long
+      alcohol_drinks_per_day:
+        type: long
+      alcohol_history:
+        type: keyword
+      alcohol_intensity:
+        type: keyword
+      asbestos_exposure:
+        type: keyword
+      bmi:
+        type: long
+      cigarettes_per_day:
+        type: float
+      coal_dust_exposure:
+        type: keyword
+      created_datetime:
+        type: keyword
+      environmental_tobacco_smoke_exposure:
+        type: keyword
+      exposure_id:
+        type: keyword
+      height:
+        type: long
+      pack_years_smoked:
+        type: long
+      radon_exposure:
+        type: keyword
+      respirable_crystalline_silica_exposure:
+        type: keyword
+      smoking_frequency:
+        type: keyword
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      time_between_waking_and_first_smoke:
+        type: keyword
+      tobacco_smoking_onset_year:
+        type: long
+      tobacco_smoking_quit_year:
+        type: long
+      tobacco_smoking_status:
+        type: keyword
+      type_of_smoke_exposure:
+        type: keyword
+      type_of_tobacco_used:
+        type: keyword
+      updated_datetime:
+        type: keyword
+      weight:
+        type: long
+      years_smoked:
+        type: long
+    type: nested
+  family_histories:
+    properties:
+      created_datetime:
+        type: keyword
+      family_history_id:
+        type: keyword
+      relationship_age_at_diagnosis:
+        type: long
+      relationship_gender:
+        type: keyword
+      relationship_primary_diagnosis:
+        type: keyword
+      relationship_type:
+        type: keyword
+      relative_with_cancer_history:
+        type: keyword
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  files:
+    properties:
+      access:
+        type: keyword
+      acl:
+        type: keyword
+      archive:
+        properties:
+          archive_id:
+            type: keyword
+          created_datetime:
+            type: keyword
+          data_category:
+            type: keyword
+          data_format:
+            type: keyword
+          data_type:
+            type: keyword
+          error_type:
+            type: keyword
+          file_name:
+            type: keyword
+          file_size:
+            type: long
+          md5sum:
+            type: keyword
+          revision:
+            type: long
+          state:
+            type: keyword
+          state_comment:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+      center:
+        properties:
+          center_id:
+            type: keyword
+          center_type:
+            type: keyword
+          code:
+            type: keyword
+          name:
+            type: keyword
+          namespace:
+            type: keyword
+          short_name:
+            type: keyword
+      created_datetime:
+        type: keyword
+      data_category:
+        type: keyword
+      data_format:
+        type: keyword
+      data_type:
+        type: keyword
+      error_type:
+        type: keyword
+      experimental_strategy:
+        type: keyword
+      file_id:
+        type: keyword
+      file_name:
+        type: keyword
+      file_size:
+        type: long
+      index_files:
+        properties:
+          created_datetime:
+            type: keyword
+          data_format:
+            type: keyword
+          error_type:
+            type: keyword
+          file_id:
+            type: keyword
+          file_name:
+            type: keyword
+          file_size:
+            type: long
+          md5sum:
+            type: keyword
+          state:
+            type: keyword
+          state_comment:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      md5sum:
+        type: keyword
+      metadata_files:
+        properties:
+          access:
+            type: keyword
+          created_datetime:
+            type: keyword
+          data_category:
+            type: keyword
+          data_format:
+            type: keyword
+          data_type:
+            type: keyword
+          error_type:
+            type: keyword
+          file_id:
+            type: keyword
+          file_name:
+            type: keyword
+          file_size:
+            type: long
+          md5sum:
+            type: keyword
+          state:
+            type: keyword
+          state_comment:
+            type: keyword
+          submitter_id:
+            type: keyword
+          type:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      origin:
+        type: keyword
+      platform:
+        type: keyword
+      state:
+        type: keyword
+      state_comment:
+        type: keyword
+      submitter_id:
+        type: keyword
+      tags:
+        type: keyword
+      type:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  follow_ups:
+    properties:
+      adverse_event:
+        type: keyword
+      barretts_esophagus_goblet_cells_present:
+        type: keyword
+      bmi:
+        type: long
+      cause_of_response:
+        type: keyword
+      comorbidity:
+        type: keyword
+      comorbidity_method_of_diagnosis:
+        type: keyword
+      created_datetime:
+        type: keyword
+      days_to_adverse_event:
+        type: long
+      days_to_comorbidity:
+        type: long
+      days_to_follow_up:
+        type: long
+      days_to_progression:
+        type: long
+      days_to_progression_free:
+        type: long
+      days_to_recurrence:
+        type: long
+      diabetes_treatment_type:
+        type: keyword
+      disease_response:
+        type: keyword
+      dlco_ref_predictive_percent:
+        type: long
+      ecog_performance_status:
+        type: keyword
+      fev1_fvc_post_bronch_percent:
+        type: long
+      fev1_fvc_pre_bronch_percent:
+        type: long
+      fev1_ref_post_bronch_percent:
+        type: long
+      fev1_ref_pre_bronch_percent:
+        type: long
+      follow_up_id:
+        type: keyword
+      height:
+        type: long
+      hepatitis_sustained_virological_response:
+        type: keyword
+      hpv_positive_type:
+        type: keyword
+      karnofsky_performance_status:
+        type: keyword
+      menopause_status:
+        type: keyword
+      molecular_tests:
+        properties:
+          aa_change:
+            type: keyword
+          antigen:
+            type: keyword
+          biospecimen_type:
+            type: keyword
+          blood_test_normal_range_lower:
+            type: long
+          blood_test_normal_range_upper:
+            type: long
+          cell_count:
+            type: long
+          chromosome:
+            type: keyword
+          copy_number:
+            type: long
+          created_datetime:
+            type: keyword
+          cytoband:
+            type: keyword
+          exon:
+            type: keyword
+          gene_symbol:
+            type: keyword
+          histone_family:
+            type: keyword
+          histone_variant:
+            type: keyword
+          intron:
+            type: keyword
+          laboratory_test:
+            type: keyword
+          loci_abnormal_count:
+            type: long
+          loci_count:
+            type: long
+          locus:
+            type: keyword
+          mismatch_repair_mutation:
+            type: keyword
+          molecular_analysis_method:
+            type: keyword
+          molecular_consequence:
+            type: keyword
+          molecular_test_id:
+            type: keyword
+          ploidy:
+            type: keyword
+          second_exon:
+            type: keyword
+          second_gene_symbol:
+            type: keyword
+          specialized_molecular_test:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          test_analyte_type:
+            type: keyword
+          test_result:
+            type: keyword
+          test_units:
+            type: keyword
+          test_value:
+            type: long
+          transcript:
+            type: keyword
+          updated_datetime:
+            type: keyword
+          variant_origin:
+            type: keyword
+          variant_type:
+            type: keyword
+          zygosity:
+            type: keyword
+        type: nested
+      pancreatitis_onset_year:
+        type: long
+      progression_or_recurrence:
+        type: keyword
+      progression_or_recurrence_anatomic_site:
+        type: keyword
+      progression_or_recurrence_type:
+        type: keyword
+      reflux_treatment_type:
+        type: keyword
+      risk_factor:
+        type: keyword
+      risk_factor_treatment:
+        type: keyword
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+      viral_hepatitis_serologies:
+        type: keyword
+      weight:
+        type: long
+    type: nested
+  index_date:
+    type: keyword
+  lost_to_followup:
+    type: keyword
+  portion_ids:
+    type: keyword
+  primary_site:
+    type: keyword
+  project:
+    properties:
+      dbgap_accession_number:
+        type: keyword
+      disease_type:
+        type: keyword
+      intended_release_date:
+        type: keyword
+      name:
+        type: keyword
+      primary_site:
+        type: keyword
+      program:
+        properties:
+          dbgap_accession_number:
+            type: keyword
+          name:
+            type: keyword
+          program_id:
+            type: keyword
+      project_id:
+        type: keyword
+      releasable:
+        type: keyword
+      released:
+        type: keyword
+      state:
+        type: keyword
+  sample_ids:
+    type: keyword
+  samples:
+    properties:
+      annotations:
+        properties:
+          annotation_id:
+            type: keyword
+          case_id:
+            type: keyword
+          case_submitter_id:
+            type: keyword
+          category:
+            type: keyword
+          classification:
+            type: keyword
+          created_datetime:
+            type: keyword
+          creator:
+            type: keyword
+          entity_id:
+            type: keyword
+          entity_submitter_id:
+            type: keyword
+          entity_type:
+            type: keyword
+          legacy_created_datetime:
+            type: keyword
+          legacy_updated_datetime:
+            type: keyword
+          notes:
+            type: keyword
+          state:
+            type: keyword
+          status:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      biospecimen_anatomic_site:
+        type: keyword
+      biospecimen_laterality:
+        type: keyword
+      catalog_reference:
+        type: keyword
+      composition:
+        type: keyword
+      created_datetime:
+        type: keyword
+      current_weight:
+        type: long
+      days_to_collection:
+        type: long
+      days_to_sample_procurement:
+        type: long
+      diagnosis_pathologically_confirmed:
+        type: keyword
+      distance_normal_to_tumor:
+        type: keyword
+      distributor_reference:
+        type: keyword
+      freezing_method:
+        type: keyword
+      growth_rate:
+        type: long
+      initial_weight:
+        type: long
+      intermediate_dimension:
+        type: long
+      is_ffpe:
+        type: keyword
+      longest_dimension:
+        type: long
+      method_of_sample_procurement:
+        type: keyword
+      oct_embedded:
+        type: keyword
+      passage_count:
+        type: long
+      pathology_report_uuid:
+        type: keyword
+      portions:
+        properties:
+          analytes:
+            properties:
+              a260_a280_ratio:
+                type: long
+              aliquots:
+                properties:
+                  aliquot_id:
+                    type: keyword
+                  aliquot_quantity:
+                    type: long
+                  aliquot_volume:
+                    type: long
+                  amount:
+                    type: long
+                  analyte_type:
+                    type: keyword
+                  analyte_type_id:
+                    type: keyword
+                  annotations:
+                    properties:
+                      annotation_id:
+                        type: keyword
+                      case_id:
+                        type: keyword
+                      case_submitter_id:
+                        type: keyword
+                      category:
+                        type: keyword
+                      classification:
+                        type: keyword
+                      created_datetime:
+                        type: keyword
+                      creator:
+                        type: keyword
+                      entity_id:
+                        type: keyword
+                      entity_submitter_id:
+                        type: keyword
+                      entity_type:
+                        type: keyword
+                      legacy_created_datetime:
+                        type: keyword
+                      legacy_updated_datetime:
+                        type: keyword
+                      notes:
+                        type: keyword
+                      state:
+                        type: keyword
+                      status:
+                        type: keyword
+                      submitter_id:
+                        type: keyword
+                      updated_datetime:
+                        type: keyword
+                    type: nested
+                  center:
+                    properties:
+                      center_id:
+                        type: keyword
+                      center_type:
+                        type: keyword
+                      code:
+                        type: keyword
+                      name:
+                        type: keyword
+                      namespace:
+                        type: keyword
+                      short_name:
+                        type: keyword
+                  concentration:
+                    type: long
+                  created_datetime:
+                    type: keyword
+                  no_matched_normal_low_pass_wgs:
+                    type: keyword
+                  no_matched_normal_targeted_sequencing:
+                    type: keyword
+                  no_matched_normal_wgs:
+                    type: keyword
+                  no_matched_normal_wxs:
+                    type: keyword
+                  selected_normal_low_pass_wgs:
+                    type: keyword
+                  selected_normal_targeted_sequencing:
+                    type: keyword
+                  selected_normal_wgs:
+                    type: keyword
+                  selected_normal_wxs:
+                    type: keyword
+                  source_center:
+                    type: keyword
+                  state:
+                    type: keyword
+                  submitter_id:
+                    type: keyword
+                  updated_datetime:
+                    type: keyword
+                type: nested
+              amount:
+                type: long
+              analyte_id:
+                type: keyword
+              analyte_quantity:
+                type: long
+              analyte_type:
+                type: keyword
+              analyte_type_id:
+                type: keyword
+              analyte_volume:
+                type: long
+              annotations:
+                properties:
+                  annotation_id:
+                    type: keyword
+                  case_id:
+                    type: keyword
+                  case_submitter_id:
+                    type: keyword
+                  category:
+                    type: keyword
+                  classification:
+                    type: keyword
+                  created_datetime:
+                    type: keyword
+                  creator:
+                    type: keyword
+                  entity_id:
+                    type: keyword
+                  entity_submitter_id:
+                    type: keyword
+                  entity_type:
+                    type: keyword
+                  legacy_created_datetime:
+                    type: keyword
+                  legacy_updated_datetime:
+                    type: keyword
+                  notes:
+                    type: keyword
+                  state:
+                    type: keyword
+                  status:
+                    type: keyword
+                  submitter_id:
+                    type: keyword
+                  updated_datetime:
+                    type: keyword
+                type: nested
+              concentration:
+                type: long
+              created_datetime:
+                type: keyword
+              normal_tumor_genotype_snp_match:
+                type: keyword
+              ribosomal_rna_28s_16s_ratio:
+                type: long
+              spectrophotometer_method:
+                type: keyword
+              state:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: keyword
+              well_number:
+                type: keyword
+            type: nested
+          annotations:
+            properties:
+              annotation_id:
+                type: keyword
+              case_id:
+                type: keyword
+              case_submitter_id:
+                type: keyword
+              category:
+                type: keyword
+              classification:
+                type: keyword
+              created_datetime:
+                type: keyword
+              creator:
+                type: keyword
+              entity_id:
+                type: keyword
+              entity_submitter_id:
+                type: keyword
+              entity_type:
+                type: keyword
+              legacy_created_datetime:
+                type: keyword
+              legacy_updated_datetime:
+                type: keyword
+              notes:
+                type: keyword
+              state:
+                type: keyword
+              status:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: keyword
+            type: nested
+          center:
+            properties:
+              center_id:
+                type: keyword
+              center_type:
+                type: keyword
+              code:
+                type: keyword
+              name:
+                type: keyword
+              namespace:
+                type: keyword
+              short_name:
+                type: keyword
+          created_datetime:
+            type: keyword
+          creation_datetime:
+            type: long
+          is_ffpe:
+            type: keyword
+          portion_id:
+            type: keyword
+          portion_number:
+            type: keyword
+          slides:
+            properties:
+              annotations:
+                properties:
+                  annotation_id:
+                    type: keyword
+                  case_id:
+                    type: keyword
+                  case_submitter_id:
+                    type: keyword
+                  category:
+                    type: keyword
+                  classification:
+                    type: keyword
+                  created_datetime:
+                    type: keyword
+                  creator:
+                    type: keyword
+                  entity_id:
+                    type: keyword
+                  entity_submitter_id:
+                    type: keyword
+                  entity_type:
+                    type: keyword
+                  legacy_created_datetime:
+                    type: keyword
+                  legacy_updated_datetime:
+                    type: keyword
+                  notes:
+                    type: keyword
+                  state:
+                    type: keyword
+                  status:
+                    type: keyword
+                  submitter_id:
+                    type: keyword
+                  updated_datetime:
+                    type: keyword
+                type: nested
+              created_datetime:
+                type: keyword
+              number_proliferating_cells:
+                type: long
+              percent_eosinophil_infiltration:
+                type: long
+              percent_granulocyte_infiltration:
+                type: long
+              percent_inflam_infiltration:
+                type: long
+              percent_lymphocyte_infiltration:
+                type: long
+              percent_monocyte_infiltration:
+                type: long
+              percent_necrosis:
+                type: long
+              percent_neutrophil_infiltration:
+                type: long
+              percent_normal_cells:
+                type: long
+              percent_stromal_cells:
+                type: long
+              percent_tumor_cells:
+                type: long
+              percent_tumor_nuclei:
+                type: long
+              section_location:
+                type: keyword
+              slide_id:
+                type: keyword
+              state:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: keyword
+            type: nested
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+          weight:
+            type: long
+        type: nested
+      preservation_method:
+        type: keyword
+      sample_id:
+        type: keyword
+      sample_type:
+        type: keyword
+      sample_type_id:
+        type: keyword
+      shortest_dimension:
+        type: long
+      state:
+        type: keyword
+      submitter_id:
+        type: keyword
+      time_between_clamping_and_freezing:
+        type: long
+      time_between_excision_and_freezing:
+        type: long
+      tissue_type:
+        type: keyword
+      tumor_code:
+        type: keyword
+      tumor_code_id:
+        type: keyword
+      tumor_descriptor:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  slide_ids:
+    type: keyword
+  state:
+    type: keyword
+  submitter_aliquot_ids:
+    type: keyword
+  submitter_analyte_ids:
+    type: keyword
+  submitter_diagnosis_ids:
+    type: keyword
+  submitter_id:
+    type: keyword
+  submitter_portion_ids:
+    type: keyword
+  submitter_sample_ids:
+    type: keyword
+  submitter_slide_ids:
+    type: keyword
+  summary:
+    properties:
+      data_categories:
+        properties:
+          data_category:
+            type: keyword
+          file_count:
+            type: long
+        type: nested
+      experimental_strategies:
+        properties:
+          experimental_strategy:
+            type: keyword
+          file_count:
+            type: long
+        type: nested
+      file_count:
+        type: long
+      file_size:
+        type: long
+  tissue_source_site:
+    properties:
+      bcr_id:
+        type: keyword
+      code:
+        type: keyword
+      name:
+        type: keyword
+      project:
+        type: keyword
+      tissue_source_site_id:
+        type: keyword
+  updated_datetime:
+    type: keyword

--- a/es-models/gdc_legacy_graph/file.mapping.yaml
+++ b/es-models/gdc_legacy_graph/file.mapping.yaml
@@ -1,0 +1,1302 @@
+properties:
+  access:
+    type: keyword
+  acl:
+    type: keyword
+  annotations:
+    properties:
+      annotation_id:
+        type: keyword
+      case_id:
+        type: keyword
+      case_submitter_id:
+        type: keyword
+      category:
+        type: keyword
+      classification:
+        type: keyword
+      created_datetime:
+        type: keyword
+      creator:
+        type: keyword
+      entity_id:
+        type: keyword
+      entity_submitter_id:
+        type: keyword
+      entity_type:
+        type: keyword
+      legacy_created_datetime:
+        type: keyword
+      legacy_updated_datetime:
+        type: keyword
+      notes:
+        type: keyword
+      state:
+        type: keyword
+      status:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  archive:
+    properties:
+      archive_id:
+        type: keyword
+      created_datetime:
+        type: keyword
+      data_category:
+        type: keyword
+      data_format:
+        type: keyword
+      data_type:
+        type: keyword
+      error_type:
+        type: keyword
+      file_name:
+        type: keyword
+      file_size:
+        type: long
+      md5sum:
+        type: keyword
+      revision:
+        type: long
+      state:
+        type: keyword
+      state_comment:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+  associated_entities:
+    properties:
+      case_id:
+        type: keyword
+      entity_id:
+        type: keyword
+      entity_submitter_id:
+        type: keyword
+      entity_type:
+        type: keyword
+    type: nested
+  cases:
+    properties:
+      aliquot_ids:
+        type: keyword
+      analyte_ids:
+        type: keyword
+      annotations:
+        properties:
+          annotation_id:
+            type: keyword
+          case_id:
+            type: keyword
+          case_submitter_id:
+            type: keyword
+          category:
+            type: keyword
+          classification:
+            type: keyword
+          created_datetime:
+            type: keyword
+          creator:
+            type: keyword
+          entity_id:
+            type: keyword
+          entity_submitter_id:
+            type: keyword
+          entity_type:
+            type: keyword
+          legacy_created_datetime:
+            type: keyword
+          legacy_updated_datetime:
+            type: keyword
+          notes:
+            type: keyword
+          state:
+            type: keyword
+          status:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      case_id:
+        type: keyword
+      created_datetime:
+        type: keyword
+      days_to_index:
+        type: long
+      days_to_lost_to_followup:
+        type: long
+      demographic:
+        properties:
+          age_at_index:
+            type: long
+          cause_of_death:
+            type: keyword
+          created_datetime:
+            type: keyword
+          days_to_birth:
+            type: long
+          days_to_death:
+            type: long
+          demographic_id:
+            type: keyword
+          ethnicity:
+            type: keyword
+          gender:
+            type: keyword
+          premature_at_birth:
+            type: keyword
+          race:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+          vital_status:
+            type: keyword
+          weeks_gestation_at_birth:
+            type: long
+          year_of_birth:
+            type: long
+          year_of_death:
+            type: long
+      diagnoses:
+        properties:
+          age_at_diagnosis:
+            type: long
+          ajcc_clinical_m:
+            type: keyword
+          ajcc_clinical_n:
+            type: keyword
+          ajcc_clinical_stage:
+            type: keyword
+          ajcc_clinical_t:
+            type: keyword
+          ajcc_pathologic_m:
+            type: keyword
+          ajcc_pathologic_n:
+            type: keyword
+          ajcc_pathologic_stage:
+            type: keyword
+          ajcc_pathologic_t:
+            type: keyword
+          ajcc_staging_system_edition:
+            type: keyword
+          anaplasia_present:
+            type: keyword
+          anaplasia_present_type:
+            type: keyword
+          ann_arbor_b_symptoms:
+            type: keyword
+          ann_arbor_clinical_stage:
+            type: keyword
+          ann_arbor_extranodal_involvement:
+            type: keyword
+          ann_arbor_pathologic_stage:
+            type: keyword
+          annotations:
+            properties:
+              annotation_id:
+                type: keyword
+              case_id:
+                type: keyword
+              case_submitter_id:
+                type: keyword
+              category:
+                type: keyword
+              classification:
+                type: keyword
+              created_datetime:
+                type: keyword
+              creator:
+                type: keyword
+              entity_id:
+                type: keyword
+              entity_submitter_id:
+                type: keyword
+              entity_type:
+                type: keyword
+              legacy_created_datetime:
+                type: keyword
+              legacy_updated_datetime:
+                type: keyword
+              notes:
+                type: keyword
+              state:
+                type: keyword
+              status:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: keyword
+            type: nested
+          best_overall_response:
+            type: keyword
+          burkitt_lymphoma_clinical_variant:
+            type: keyword
+          child_pugh_classification:
+            type: keyword
+          circumferential_resection_margin:
+            type: long
+          classification_of_tumor:
+            type: keyword
+          cog_liver_stage:
+            type: keyword
+          cog_neuroblastoma_risk_group:
+            type: keyword
+          cog_renal_stage:
+            type: keyword
+          cog_rhabdomyosarcoma_risk_group:
+            type: keyword
+          created_datetime:
+            type: keyword
+          days_to_best_overall_response:
+            type: long
+          days_to_diagnosis:
+            type: long
+          days_to_last_follow_up:
+            type: long
+          days_to_last_known_disease_status:
+            type: long
+          days_to_recurrence:
+            type: long
+          diagnosis_id:
+            type: keyword
+          enneking_msts_grade:
+            type: keyword
+          enneking_msts_metastasis:
+            type: keyword
+          enneking_msts_stage:
+            type: keyword
+          enneking_msts_tumor_site:
+            type: keyword
+          esophageal_columnar_dysplasia_degree:
+            type: keyword
+          esophageal_columnar_metaplasia_present:
+            type: keyword
+          figo_stage:
+            type: keyword
+          first_symptom_prior_to_diagnosis:
+            type: keyword
+          gastric_esophageal_junction_involvement:
+            type: keyword
+          gleason_grade_group:
+            type: keyword
+          goblet_cells_columnar_mucosa_present:
+            type: keyword
+          gross_tumor_weight:
+            type: long
+          icd_10_code:
+            type: keyword
+          igcccg_stage:
+            type: keyword
+          inpc_grade:
+            type: keyword
+          inpc_histologic_group:
+            type: keyword
+          inrg_stage:
+            type: keyword
+          inss_stage:
+            type: keyword
+          irs_group:
+            type: keyword
+          irs_stage:
+            type: keyword
+          ishak_fibrosis_score:
+            type: keyword
+          iss_stage:
+            type: keyword
+          last_known_disease_status:
+            type: keyword
+          laterality:
+            type: keyword
+          lymph_nodes_positive:
+            type: long
+          lymph_nodes_tested:
+            type: long
+          lymphatic_invasion_present:
+            type: keyword
+          masaoka_stage:
+            type: keyword
+          medulloblastoma_molecular_classification:
+            type: keyword
+          metastasis_at_diagnosis:
+            type: keyword
+          metastasis_at_diagnosis_site:
+            type: keyword
+          method_of_diagnosis:
+            type: keyword
+          micropapillary_features:
+            type: keyword
+          mitosis_karyorrhexis_index:
+            type: keyword
+          morphology:
+            type: keyword
+          perineural_invasion_present:
+            type: keyword
+          peripancreatic_lymph_nodes_positive:
+            type: keyword
+          peripancreatic_lymph_nodes_tested:
+            type: long
+          primary_diagnosis:
+            type: keyword
+          primary_gleason_grade:
+            type: keyword
+          prior_malignancy:
+            type: keyword
+          prior_treatment:
+            type: keyword
+          progression_or_recurrence:
+            type: keyword
+          residual_disease:
+            type: keyword
+          secondary_gleason_grade:
+            type: keyword
+          site_of_resection_or_biopsy:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          supratentorial_localization:
+            type: keyword
+          synchronous_malignancy:
+            type: keyword
+          tissue_or_organ_of_origin:
+            type: keyword
+          treatments:
+            properties:
+              created_datetime:
+                type: keyword
+              days_to_treatment_end:
+                type: long
+              days_to_treatment_start:
+                type: long
+              initial_disease_status:
+                type: keyword
+              regimen_or_line_of_therapy:
+                type: keyword
+              state:
+                type: keyword
+              submitter_id:
+                type: keyword
+              therapeutic_agents:
+                type: keyword
+              treatment_anatomic_site:
+                type: keyword
+              treatment_effect:
+                type: keyword
+              treatment_id:
+                type: keyword
+              treatment_intent_type:
+                type: keyword
+              treatment_or_therapy:
+                type: keyword
+              treatment_outcome:
+                type: keyword
+              treatment_type:
+                type: keyword
+              updated_datetime:
+                type: keyword
+            type: nested
+          tumor_confined_to_organ_of_origin:
+            type: keyword
+          tumor_focality:
+            type: keyword
+          tumor_grade:
+            type: keyword
+          tumor_largest_dimension_diameter:
+            type: long
+          tumor_regression_grade:
+            type: keyword
+          tumor_stage:
+            type: keyword
+          updated_datetime:
+            type: keyword
+          vascular_invasion_present:
+            type: keyword
+          vascular_invasion_type:
+            type: keyword
+          weiss_assessment_score:
+            type: keyword
+          wilms_tumor_histologic_subtype:
+            type: keyword
+          year_of_diagnosis:
+            type: long
+        type: nested
+      diagnosis_ids:
+        type: keyword
+      disease_type:
+        type: keyword
+      exposures:
+        properties:
+          alcohol_days_per_week:
+            type: long
+          alcohol_drinks_per_day:
+            type: long
+          alcohol_history:
+            type: keyword
+          alcohol_intensity:
+            type: keyword
+          asbestos_exposure:
+            type: keyword
+          bmi:
+            type: long
+          cigarettes_per_day:
+            type: float
+          coal_dust_exposure:
+            type: keyword
+          created_datetime:
+            type: keyword
+          environmental_tobacco_smoke_exposure:
+            type: keyword
+          exposure_id:
+            type: keyword
+          height:
+            type: long
+          pack_years_smoked:
+            type: long
+          radon_exposure:
+            type: keyword
+          respirable_crystalline_silica_exposure:
+            type: keyword
+          smoking_frequency:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          time_between_waking_and_first_smoke:
+            type: keyword
+          tobacco_smoking_onset_year:
+            type: long
+          tobacco_smoking_quit_year:
+            type: long
+          tobacco_smoking_status:
+            type: keyword
+          type_of_smoke_exposure:
+            type: keyword
+          type_of_tobacco_used:
+            type: keyword
+          updated_datetime:
+            type: keyword
+          weight:
+            type: long
+          years_smoked:
+            type: long
+        type: nested
+      family_histories:
+        properties:
+          created_datetime:
+            type: keyword
+          family_history_id:
+            type: keyword
+          relationship_age_at_diagnosis:
+            type: long
+          relationship_gender:
+            type: keyword
+          relationship_primary_diagnosis:
+            type: keyword
+          relationship_type:
+            type: keyword
+          relative_with_cancer_history:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      follow_ups:
+        properties:
+          adverse_event:
+            type: keyword
+          barretts_esophagus_goblet_cells_present:
+            type: keyword
+          bmi:
+            type: long
+          cause_of_response:
+            type: keyword
+          comorbidity:
+            type: keyword
+          comorbidity_method_of_diagnosis:
+            type: keyword
+          created_datetime:
+            type: keyword
+          days_to_adverse_event:
+            type: long
+          days_to_comorbidity:
+            type: long
+          days_to_follow_up:
+            type: long
+          days_to_progression:
+            type: long
+          days_to_progression_free:
+            type: long
+          days_to_recurrence:
+            type: long
+          diabetes_treatment_type:
+            type: keyword
+          disease_response:
+            type: keyword
+          dlco_ref_predictive_percent:
+            type: long
+          ecog_performance_status:
+            type: keyword
+          fev1_fvc_post_bronch_percent:
+            type: long
+          fev1_fvc_pre_bronch_percent:
+            type: long
+          fev1_ref_post_bronch_percent:
+            type: long
+          fev1_ref_pre_bronch_percent:
+            type: long
+          follow_up_id:
+            type: keyword
+          height:
+            type: long
+          hepatitis_sustained_virological_response:
+            type: keyword
+          hpv_positive_type:
+            type: keyword
+          karnofsky_performance_status:
+            type: keyword
+          menopause_status:
+            type: keyword
+          molecular_tests:
+            properties:
+              aa_change:
+                type: keyword
+              antigen:
+                type: keyword
+              biospecimen_type:
+                type: keyword
+              blood_test_normal_range_lower:
+                type: long
+              blood_test_normal_range_upper:
+                type: long
+              cell_count:
+                type: long
+              chromosome:
+                type: keyword
+              copy_number:
+                type: long
+              created_datetime:
+                type: keyword
+              cytoband:
+                type: keyword
+              exon:
+                type: keyword
+              gene_symbol:
+                type: keyword
+              histone_family:
+                type: keyword
+              histone_variant:
+                type: keyword
+              intron:
+                type: keyword
+              laboratory_test:
+                type: keyword
+              loci_abnormal_count:
+                type: long
+              loci_count:
+                type: long
+              locus:
+                type: keyword
+              mismatch_repair_mutation:
+                type: keyword
+              molecular_analysis_method:
+                type: keyword
+              molecular_consequence:
+                type: keyword
+              molecular_test_id:
+                type: keyword
+              ploidy:
+                type: keyword
+              second_exon:
+                type: keyword
+              second_gene_symbol:
+                type: keyword
+              specialized_molecular_test:
+                type: keyword
+              state:
+                type: keyword
+              submitter_id:
+                type: keyword
+              test_analyte_type:
+                type: keyword
+              test_result:
+                type: keyword
+              test_units:
+                type: keyword
+              test_value:
+                type: long
+              transcript:
+                type: keyword
+              updated_datetime:
+                type: keyword
+              variant_origin:
+                type: keyword
+              variant_type:
+                type: keyword
+              zygosity:
+                type: keyword
+            type: nested
+          pancreatitis_onset_year:
+            type: long
+          progression_or_recurrence:
+            type: keyword
+          progression_or_recurrence_anatomic_site:
+            type: keyword
+          progression_or_recurrence_type:
+            type: keyword
+          reflux_treatment_type:
+            type: keyword
+          risk_factor:
+            type: keyword
+          risk_factor_treatment:
+            type: keyword
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          updated_datetime:
+            type: keyword
+          viral_hepatitis_serologies:
+            type: keyword
+          weight:
+            type: long
+        type: nested
+      index_date:
+        type: keyword
+      lost_to_followup:
+        type: keyword
+      portion_ids:
+        type: keyword
+      primary_site:
+        type: keyword
+      project:
+        properties:
+          dbgap_accession_number:
+            type: keyword
+          disease_type:
+            type: keyword
+          intended_release_date:
+            type: keyword
+          name:
+            type: keyword
+          primary_site:
+            type: keyword
+          program:
+            properties:
+              dbgap_accession_number:
+                type: keyword
+              name:
+                type: keyword
+              program_id:
+                type: keyword
+          project_id:
+            type: keyword
+          releasable:
+            type: keyword
+          released:
+            type: keyword
+          state:
+            type: keyword
+      sample_ids:
+        type: keyword
+      samples:
+        properties:
+          annotations:
+            properties:
+              annotation_id:
+                type: keyword
+              case_id:
+                type: keyword
+              case_submitter_id:
+                type: keyword
+              category:
+                type: keyword
+              classification:
+                type: keyword
+              created_datetime:
+                type: keyword
+              creator:
+                type: keyword
+              entity_id:
+                type: keyword
+              entity_submitter_id:
+                type: keyword
+              entity_type:
+                type: keyword
+              legacy_created_datetime:
+                type: keyword
+              legacy_updated_datetime:
+                type: keyword
+              notes:
+                type: keyword
+              state:
+                type: keyword
+              status:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: keyword
+            type: nested
+          biospecimen_anatomic_site:
+            type: keyword
+          biospecimen_laterality:
+            type: keyword
+          catalog_reference:
+            type: keyword
+          composition:
+            type: keyword
+          created_datetime:
+            type: keyword
+          current_weight:
+            type: long
+          days_to_collection:
+            type: long
+          days_to_sample_procurement:
+            type: long
+          diagnosis_pathologically_confirmed:
+            type: keyword
+          distance_normal_to_tumor:
+            type: keyword
+          distributor_reference:
+            type: keyword
+          freezing_method:
+            type: keyword
+          growth_rate:
+            type: long
+          initial_weight:
+            type: long
+          intermediate_dimension:
+            type: long
+          is_ffpe:
+            type: keyword
+          longest_dimension:
+            type: long
+          method_of_sample_procurement:
+            type: keyword
+          oct_embedded:
+            type: keyword
+          passage_count:
+            type: long
+          pathology_report_uuid:
+            type: keyword
+          portions:
+            properties:
+              analytes:
+                properties:
+                  a260_a280_ratio:
+                    type: long
+                  aliquots:
+                    properties:
+                      aliquot_id:
+                        type: keyword
+                      aliquot_quantity:
+                        type: long
+                      aliquot_volume:
+                        type: long
+                      amount:
+                        type: long
+                      analyte_type:
+                        type: keyword
+                      analyte_type_id:
+                        type: keyword
+                      annotations:
+                        properties:
+                          annotation_id:
+                            type: keyword
+                          case_id:
+                            type: keyword
+                          case_submitter_id:
+                            type: keyword
+                          category:
+                            type: keyword
+                          classification:
+                            type: keyword
+                          created_datetime:
+                            type: keyword
+                          creator:
+                            type: keyword
+                          entity_id:
+                            type: keyword
+                          entity_submitter_id:
+                            type: keyword
+                          entity_type:
+                            type: keyword
+                          legacy_created_datetime:
+                            type: keyword
+                          legacy_updated_datetime:
+                            type: keyword
+                          notes:
+                            type: keyword
+                          state:
+                            type: keyword
+                          status:
+                            type: keyword
+                          submitter_id:
+                            type: keyword
+                          updated_datetime:
+                            type: keyword
+                        type: nested
+                      center:
+                        properties:
+                          center_id:
+                            type: keyword
+                          center_type:
+                            type: keyword
+                          code:
+                            type: keyword
+                          name:
+                            type: keyword
+                          namespace:
+                            type: keyword
+                          short_name:
+                            type: keyword
+                      concentration:
+                        type: long
+                      created_datetime:
+                        type: keyword
+                      no_matched_normal_low_pass_wgs:
+                        type: keyword
+                      no_matched_normal_targeted_sequencing:
+                        type: keyword
+                      no_matched_normal_wgs:
+                        type: keyword
+                      no_matched_normal_wxs:
+                        type: keyword
+                      selected_normal_low_pass_wgs:
+                        type: keyword
+                      selected_normal_targeted_sequencing:
+                        type: keyword
+                      selected_normal_wgs:
+                        type: keyword
+                      selected_normal_wxs:
+                        type: keyword
+                      source_center:
+                        type: keyword
+                      state:
+                        type: keyword
+                      submitter_id:
+                        type: keyword
+                      updated_datetime:
+                        type: keyword
+                    type: nested
+                  amount:
+                    type: long
+                  analyte_id:
+                    type: keyword
+                  analyte_quantity:
+                    type: long
+                  analyte_type:
+                    type: keyword
+                  analyte_type_id:
+                    type: keyword
+                  analyte_volume:
+                    type: long
+                  annotations:
+                    properties:
+                      annotation_id:
+                        type: keyword
+                      case_id:
+                        type: keyword
+                      case_submitter_id:
+                        type: keyword
+                      category:
+                        type: keyword
+                      classification:
+                        type: keyword
+                      created_datetime:
+                        type: keyword
+                      creator:
+                        type: keyword
+                      entity_id:
+                        type: keyword
+                      entity_submitter_id:
+                        type: keyword
+                      entity_type:
+                        type: keyword
+                      legacy_created_datetime:
+                        type: keyword
+                      legacy_updated_datetime:
+                        type: keyword
+                      notes:
+                        type: keyword
+                      state:
+                        type: keyword
+                      status:
+                        type: keyword
+                      submitter_id:
+                        type: keyword
+                      updated_datetime:
+                        type: keyword
+                    type: nested
+                  concentration:
+                    type: long
+                  created_datetime:
+                    type: keyword
+                  normal_tumor_genotype_snp_match:
+                    type: keyword
+                  ribosomal_rna_28s_16s_ratio:
+                    type: long
+                  spectrophotometer_method:
+                    type: keyword
+                  state:
+                    type: keyword
+                  submitter_id:
+                    type: keyword
+                  updated_datetime:
+                    type: keyword
+                  well_number:
+                    type: keyword
+                type: nested
+              annotations:
+                properties:
+                  annotation_id:
+                    type: keyword
+                  case_id:
+                    type: keyword
+                  case_submitter_id:
+                    type: keyword
+                  category:
+                    type: keyword
+                  classification:
+                    type: keyword
+                  created_datetime:
+                    type: keyword
+                  creator:
+                    type: keyword
+                  entity_id:
+                    type: keyword
+                  entity_submitter_id:
+                    type: keyword
+                  entity_type:
+                    type: keyword
+                  legacy_created_datetime:
+                    type: keyword
+                  legacy_updated_datetime:
+                    type: keyword
+                  notes:
+                    type: keyword
+                  state:
+                    type: keyword
+                  status:
+                    type: keyword
+                  submitter_id:
+                    type: keyword
+                  updated_datetime:
+                    type: keyword
+                type: nested
+              center:
+                properties:
+                  center_id:
+                    type: keyword
+                  center_type:
+                    type: keyword
+                  code:
+                    type: keyword
+                  name:
+                    type: keyword
+                  namespace:
+                    type: keyword
+                  short_name:
+                    type: keyword
+              created_datetime:
+                type: keyword
+              creation_datetime:
+                type: long
+              is_ffpe:
+                type: keyword
+              portion_id:
+                type: keyword
+              portion_number:
+                type: keyword
+              slides:
+                properties:
+                  annotations:
+                    properties:
+                      annotation_id:
+                        type: keyword
+                      case_id:
+                        type: keyword
+                      case_submitter_id:
+                        type: keyword
+                      category:
+                        type: keyword
+                      classification:
+                        type: keyword
+                      created_datetime:
+                        type: keyword
+                      creator:
+                        type: keyword
+                      entity_id:
+                        type: keyword
+                      entity_submitter_id:
+                        type: keyword
+                      entity_type:
+                        type: keyword
+                      legacy_created_datetime:
+                        type: keyword
+                      legacy_updated_datetime:
+                        type: keyword
+                      notes:
+                        type: keyword
+                      state:
+                        type: keyword
+                      status:
+                        type: keyword
+                      submitter_id:
+                        type: keyword
+                      updated_datetime:
+                        type: keyword
+                    type: nested
+                  created_datetime:
+                    type: keyword
+                  number_proliferating_cells:
+                    type: long
+                  percent_eosinophil_infiltration:
+                    type: long
+                  percent_granulocyte_infiltration:
+                    type: long
+                  percent_inflam_infiltration:
+                    type: long
+                  percent_lymphocyte_infiltration:
+                    type: long
+                  percent_monocyte_infiltration:
+                    type: long
+                  percent_necrosis:
+                    type: long
+                  percent_neutrophil_infiltration:
+                    type: long
+                  percent_normal_cells:
+                    type: long
+                  percent_stromal_cells:
+                    type: long
+                  percent_tumor_cells:
+                    type: long
+                  percent_tumor_nuclei:
+                    type: long
+                  section_location:
+                    type: keyword
+                  slide_id:
+                    type: keyword
+                  state:
+                    type: keyword
+                  submitter_id:
+                    type: keyword
+                  updated_datetime:
+                    type: keyword
+                type: nested
+              state:
+                type: keyword
+              submitter_id:
+                type: keyword
+              updated_datetime:
+                type: keyword
+              weight:
+                type: long
+            type: nested
+          preservation_method:
+            type: keyword
+          sample_id:
+            type: keyword
+          sample_type:
+            type: keyword
+          sample_type_id:
+            type: keyword
+          shortest_dimension:
+            type: long
+          state:
+            type: keyword
+          submitter_id:
+            type: keyword
+          time_between_clamping_and_freezing:
+            type: long
+          time_between_excision_and_freezing:
+            type: long
+          tissue_type:
+            type: keyword
+          tumor_code:
+            type: keyword
+          tumor_code_id:
+            type: keyword
+          tumor_descriptor:
+            type: keyword
+          updated_datetime:
+            type: keyword
+        type: nested
+      slide_ids:
+        type: keyword
+      state:
+        type: keyword
+      submitter_aliquot_ids:
+        type: keyword
+      submitter_analyte_ids:
+        type: keyword
+      submitter_diagnosis_ids:
+        type: keyword
+      submitter_id:
+        type: keyword
+      submitter_portion_ids:
+        type: keyword
+      submitter_sample_ids:
+        type: keyword
+      submitter_slide_ids:
+        type: keyword
+      summary:
+        properties:
+          data_categories:
+            properties:
+              data_category:
+                type: keyword
+              file_count:
+                type: long
+            type: nested
+          experimental_strategies:
+            properties:
+              experimental_strategy:
+                type: keyword
+              file_count:
+                type: long
+            type: nested
+          file_count:
+            type: long
+          file_size:
+            type: long
+      tissue_source_site:
+        properties:
+          bcr_id:
+            type: keyword
+          code:
+            type: keyword
+          name:
+            type: keyword
+          project:
+            type: keyword
+          tissue_source_site_id:
+            type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  center:
+    properties:
+      center_id:
+        type: keyword
+      center_type:
+        type: keyword
+      code:
+        type: keyword
+      name:
+        type: keyword
+      namespace:
+        type: keyword
+      short_name:
+        type: keyword
+  created_datetime:
+    type: keyword
+  data_category:
+    type: keyword
+  data_format:
+    type: keyword
+  data_type:
+    type: keyword
+  error_type:
+    type: keyword
+  experimental_strategy:
+    type: keyword
+  file_id:
+    type: keyword
+  file_name:
+    type: keyword
+  file_size:
+    type: long
+  index_files:
+    properties:
+      created_datetime:
+        type: keyword
+      data_format:
+        type: keyword
+      error_type:
+        type: keyword
+      file_id:
+        type: keyword
+      file_name:
+        type: keyword
+      file_size:
+        type: long
+      md5sum:
+        type: keyword
+      state:
+        type: keyword
+      state_comment:
+        type: keyword
+      submitter_id:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  md5sum:
+    type: keyword
+  metadata_files:
+    properties:
+      access:
+        type: keyword
+      created_datetime:
+        type: keyword
+      data_category:
+        type: keyword
+      data_format:
+        type: keyword
+      data_type:
+        type: keyword
+      error_type:
+        type: keyword
+      file_id:
+        type: keyword
+      file_name:
+        type: keyword
+      file_size:
+        type: long
+      md5sum:
+        type: keyword
+      state:
+        type: keyword
+      state_comment:
+        type: keyword
+      submitter_id:
+        type: keyword
+      type:
+        type: keyword
+      updated_datetime:
+        type: keyword
+    type: nested
+  origin:
+    type: keyword
+  platform:
+    type: keyword
+  state:
+    type: keyword
+  state_comment:
+    type: keyword
+  submitter_id:
+    type: keyword
+  tags:
+    type: keyword
+  type:
+    type: keyword
+  updated_datetime:
+    type: keyword

--- a/es-models/gdc_legacy_graph/project.mapping.yaml
+++ b/es-models/gdc_legacy_graph/project.mapping.yaml
@@ -1,0 +1,53 @@
+properties:
+  dbgap_accession_number:
+    type: keyword
+  disease_type:
+    type: keyword
+  intended_release_date:
+    type: keyword
+  name:
+    type: keyword
+  primary_site:
+    type: keyword
+  program:
+    properties:
+      dbgap_accession_number:
+        type: keyword
+      name:
+        type: keyword
+      program_id:
+        type: keyword
+  project_id:
+    type: keyword
+  releasable:
+    type: keyword
+  released:
+    type: keyword
+  state:
+    type: keyword
+  summary:
+    properties:
+      case_count:
+        type: long
+      data_categories:
+        properties:
+          case_count:
+            type: long
+          data_category:
+            type: keyword
+          file_count:
+            type: long
+        type: nested
+      experimental_strategies:
+        properties:
+          case_count:
+            type: long
+          experimental_strategy:
+            type: keyword
+          file_count:
+            type: long
+        type: nested
+      file_count:
+        type: long
+      file_size:
+        type: long

--- a/es-models/gdc_legacy_graph/settings.yaml
+++ b/es-models/gdc_legacy_graph/settings.yaml
@@ -1,0 +1,14 @@
+analysis:
+  analyzer:
+    lowercase_keyword:
+      filter:
+      - lowercase
+      tokenizer: keyword
+  filter:
+    edge_ngram:
+      max_gram: 20
+      min_gram: 2
+      side: front
+      type: edge_ngram
+index.max_result_window: 100000000
+mapping.nested_fields.limit: 150

--- a/tests/test_es_models.py
+++ b/tests/test_es_models.py
@@ -23,7 +23,7 @@ def test_missing_required_args(input_args):
 def test_get_es_models_standard_behavior():
     models = get_es_models()
 
-    assert len(models) == 11
+    assert len(models) == 12
 
 
 def test_get_es_models_parametrized(mock_listdir):


### PR DESCRIPTION
Since we are breaking GDC API's dependency on ESBuild, we need to load mappings for Legacy ES indices from the same source as the other mappings, i.e. here.