### PR TITLE
use actual ES mappings dump for legacy

### DIFF
--- a/es-models/gdc_legacy_graph/case.mapping.yaml
+++ b/es-models/gdc_legacy_graph/case.mapping.yaml
@@ -50,8 +50,6 @@ properties:
     type: long
   demographic:
     properties:
-      age_at_index:
-        type: long
       cause_of_death:
         type: keyword
       created_datetime:
@@ -66,8 +64,6 @@ properties:
         type: keyword
       gender:
         type: keyword
-      premature_at_birth:
-        type: keyword
       race:
         type: keyword
       state:
@@ -78,8 +74,6 @@ properties:
         type: keyword
       vital_status:
         type: keyword
-      weeks_gestation_at_birth:
-        type: long
       year_of_birth:
         type: long
       year_of_death:
@@ -104,12 +98,6 @@ properties:
         type: keyword
       ajcc_pathologic_t:
         type: keyword
-      ajcc_staging_system_edition:
-        type: keyword
-      anaplasia_present:
-        type: keyword
-      anaplasia_present_type:
-        type: keyword
       ann_arbor_b_symptoms:
         type: keyword
       ann_arbor_clinical_stage:
@@ -118,116 +106,47 @@ properties:
         type: keyword
       ann_arbor_pathologic_stage:
         type: keyword
-      annotations:
-        properties:
-          annotation_id:
-            type: keyword
-          case_id:
-            type: keyword
-          case_submitter_id:
-            type: keyword
-          category:
-            type: keyword
-          classification:
-            type: keyword
-          created_datetime:
-            type: keyword
-          creator:
-            type: keyword
-          entity_id:
-            type: keyword
-          entity_submitter_id:
-            type: keyword
-          entity_type:
-            type: keyword
-          legacy_created_datetime:
-            type: keyword
-          legacy_updated_datetime:
-            type: keyword
-          notes:
-            type: keyword
-          state:
-            type: keyword
-          status:
-            type: keyword
-          submitter_id:
-            type: keyword
-          updated_datetime:
-            type: keyword
-        type: nested
       best_overall_response:
         type: keyword
       burkitt_lymphoma_clinical_variant:
         type: keyword
-      child_pugh_classification:
+      cause_of_death:
         type: keyword
       circumferential_resection_margin:
         type: long
       classification_of_tumor:
         type: keyword
-      cog_liver_stage:
-        type: keyword
-      cog_neuroblastoma_risk_group:
-        type: keyword
-      cog_renal_stage:
-        type: keyword
-      cog_rhabdomyosarcoma_risk_group:
+      colon_polyps_history:
         type: keyword
       created_datetime:
         type: keyword
       days_to_best_overall_response:
         type: long
+      days_to_birth:
+        type: long
+      days_to_death:
+        type: long
       days_to_diagnosis:
+        type: long
+      days_to_hiv_diagnosis:
         type: long
       days_to_last_follow_up:
         type: long
       days_to_last_known_disease_status:
         type: long
+      days_to_new_event:
+        type: long
       days_to_recurrence:
         type: long
       diagnosis_id:
         type: keyword
-      enneking_msts_grade:
-        type: keyword
-      enneking_msts_metastasis:
-        type: keyword
-      enneking_msts_stage:
-        type: keyword
-      enneking_msts_tumor_site:
-        type: keyword
-      esophageal_columnar_dysplasia_degree:
-        type: keyword
-      esophageal_columnar_metaplasia_present:
-        type: keyword
       figo_stage:
         type: keyword
-      first_symptom_prior_to_diagnosis:
+      hiv_positive:
         type: keyword
-      gastric_esophageal_junction_involvement:
+      hpv_positive_type:
         type: keyword
-      gleason_grade_group:
-        type: keyword
-      goblet_cells_columnar_mucosa_present:
-        type: keyword
-      gross_tumor_weight:
-        type: long
-      icd_10_code:
-        type: keyword
-      igcccg_stage:
-        type: keyword
-      inpc_grade:
-        type: keyword
-      inpc_histologic_group:
-        type: keyword
-      inrg_stage:
-        type: keyword
-      inss_stage:
-        type: keyword
-      irs_group:
-        type: keyword
-      irs_stage:
-        type: keyword
-      ishak_fibrosis_score:
+      hpv_status:
         type: keyword
       iss_stage:
         type: keyword
@@ -235,47 +154,39 @@ properties:
         type: keyword
       laterality:
         type: keyword
-      lymph_nodes_positive:
+      ldh_level_at_diagnosis:
         type: long
-      lymph_nodes_tested:
+      ldh_normal_range_upper:
+        type: long
+      lymph_nodes_positive:
         type: long
       lymphatic_invasion_present:
         type: keyword
-      masaoka_stage:
-        type: keyword
-      medulloblastoma_molecular_classification:
-        type: keyword
-      metastasis_at_diagnosis:
-        type: keyword
-      metastasis_at_diagnosis_site:
-        type: keyword
       method_of_diagnosis:
-        type: keyword
-      micropapillary_features:
-        type: keyword
-      mitosis_karyorrhexis_index:
         type: keyword
       morphology:
         type: keyword
+      new_event_anatomic_site:
+        type: keyword
+      new_event_type:
+        type: keyword
+      overall_survival:
+        type: long
       perineural_invasion_present:
         type: keyword
-      peripancreatic_lymph_nodes_positive:
-        type: keyword
-      peripancreatic_lymph_nodes_tested:
-        type: long
       primary_diagnosis:
-        type: keyword
-      primary_gleason_grade:
         type: keyword
       prior_malignancy:
         type: keyword
       prior_treatment:
         type: keyword
+      progression_free_survival:
+        type: long
+      progression_free_survival_event:
+        type: keyword
       progression_or_recurrence:
         type: keyword
       residual_disease:
-        type: keyword
-      secondary_gleason_grade:
         type: keyword
       site_of_resection_or_biopsy:
         type: keyword
@@ -283,22 +194,18 @@ properties:
         type: keyword
       submitter_id:
         type: keyword
-      supratentorial_localization:
-        type: keyword
-      synchronous_malignancy:
-        type: keyword
       tissue_or_organ_of_origin:
         type: keyword
       treatments:
         properties:
           created_datetime:
             type: keyword
+          days_to_treatment:
+            type: long
           days_to_treatment_end:
             type: long
           days_to_treatment_start:
             type: long
-          initial_disease_status:
-            type: keyword
           regimen_or_line_of_therapy:
             type: keyword
           state:
@@ -308,8 +215,6 @@ properties:
           therapeutic_agents:
             type: keyword
           treatment_anatomic_site:
-            type: keyword
-          treatment_effect:
             type: keyword
           treatment_id:
             type: keyword
@@ -324,15 +229,7 @@ properties:
           updated_datetime:
             type: keyword
         type: nested
-      tumor_confined_to_organ_of_origin:
-        type: keyword
-      tumor_focality:
-        type: keyword
       tumor_grade:
-        type: keyword
-      tumor_largest_dimension_diameter:
-        type: long
-      tumor_regression_grade:
         type: keyword
       tumor_stage:
         type: keyword
@@ -340,40 +237,24 @@ properties:
         type: keyword
       vascular_invasion_present:
         type: keyword
-      vascular_invasion_type:
-        type: keyword
-      weiss_assessment_score:
-        type: keyword
-      wilms_tumor_histologic_subtype:
+      vital_status:
         type: keyword
       year_of_diagnosis:
         type: long
     type: nested
-  diagnosis_ids:
-    type: keyword
   disease_type:
     type: keyword
   exposures:
     properties:
-      alcohol_days_per_week:
-        type: long
-      alcohol_drinks_per_day:
-        type: long
       alcohol_history:
         type: keyword
       alcohol_intensity:
-        type: keyword
-      asbestos_exposure:
         type: keyword
       bmi:
         type: long
       cigarettes_per_day:
         type: float
-      coal_dust_exposure:
-        type: keyword
       created_datetime:
-        type: keyword
-      environmental_tobacco_smoke_exposure:
         type: keyword
       exposure_id:
         type: keyword
@@ -381,27 +262,15 @@ properties:
         type: long
       pack_years_smoked:
         type: long
-      radon_exposure:
-        type: keyword
-      respirable_crystalline_silica_exposure:
-        type: keyword
-      smoking_frequency:
-        type: keyword
       state:
         type: keyword
       submitter_id:
-        type: keyword
-      time_between_waking_and_first_smoke:
         type: keyword
       tobacco_smoking_onset_year:
         type: long
       tobacco_smoking_quit_year:
         type: long
       tobacco_smoking_status:
-        type: keyword
-      type_of_smoke_exposure:
-        type: keyword
-      type_of_tobacco_used:
         type: keyword
       updated_datetime:
         type: keyword
@@ -457,6 +326,8 @@ properties:
             type: keyword
           file_size:
             type: long
+          file_state:
+            type: keyword
           md5sum:
             type: keyword
           revision:
@@ -501,6 +372,8 @@ properties:
         type: keyword
       file_size:
         type: long
+      file_state:
+        type: keyword
       index_files:
         properties:
           created_datetime:
@@ -515,6 +388,8 @@ properties:
             type: keyword
           file_size:
             type: long
+          file_state:
+            type: keyword
           md5sum:
             type: keyword
           state:
@@ -548,6 +423,8 @@ properties:
             type: keyword
           file_size:
             type: long
+          file_state:
+            type: keyword
           md5sum:
             type: keyword
           state:
@@ -577,166 +454,6 @@ properties:
         type: keyword
       updated_datetime:
         type: keyword
-    type: nested
-  follow_ups:
-    properties:
-      adverse_event:
-        type: keyword
-      barretts_esophagus_goblet_cells_present:
-        type: keyword
-      bmi:
-        type: long
-      cause_of_response:
-        type: keyword
-      comorbidity:
-        type: keyword
-      comorbidity_method_of_diagnosis:
-        type: keyword
-      created_datetime:
-        type: keyword
-      days_to_adverse_event:
-        type: long
-      days_to_comorbidity:
-        type: long
-      days_to_follow_up:
-        type: long
-      days_to_progression:
-        type: long
-      days_to_progression_free:
-        type: long
-      days_to_recurrence:
-        type: long
-      diabetes_treatment_type:
-        type: keyword
-      disease_response:
-        type: keyword
-      dlco_ref_predictive_percent:
-        type: long
-      ecog_performance_status:
-        type: keyword
-      fev1_fvc_post_bronch_percent:
-        type: long
-      fev1_fvc_pre_bronch_percent:
-        type: long
-      fev1_ref_post_bronch_percent:
-        type: long
-      fev1_ref_pre_bronch_percent:
-        type: long
-      follow_up_id:
-        type: keyword
-      height:
-        type: long
-      hepatitis_sustained_virological_response:
-        type: keyword
-      hpv_positive_type:
-        type: keyword
-      karnofsky_performance_status:
-        type: keyword
-      menopause_status:
-        type: keyword
-      molecular_tests:
-        properties:
-          aa_change:
-            type: keyword
-          antigen:
-            type: keyword
-          biospecimen_type:
-            type: keyword
-          blood_test_normal_range_lower:
-            type: long
-          blood_test_normal_range_upper:
-            type: long
-          cell_count:
-            type: long
-          chromosome:
-            type: keyword
-          copy_number:
-            type: long
-          created_datetime:
-            type: keyword
-          cytoband:
-            type: keyword
-          exon:
-            type: keyword
-          gene_symbol:
-            type: keyword
-          histone_family:
-            type: keyword
-          histone_variant:
-            type: keyword
-          intron:
-            type: keyword
-          laboratory_test:
-            type: keyword
-          loci_abnormal_count:
-            type: long
-          loci_count:
-            type: long
-          locus:
-            type: keyword
-          mismatch_repair_mutation:
-            type: keyword
-          molecular_analysis_method:
-            type: keyword
-          molecular_consequence:
-            type: keyword
-          molecular_test_id:
-            type: keyword
-          ploidy:
-            type: keyword
-          second_exon:
-            type: keyword
-          second_gene_symbol:
-            type: keyword
-          specialized_molecular_test:
-            type: keyword
-          state:
-            type: keyword
-          submitter_id:
-            type: keyword
-          test_analyte_type:
-            type: keyword
-          test_result:
-            type: keyword
-          test_units:
-            type: keyword
-          test_value:
-            type: long
-          transcript:
-            type: keyword
-          updated_datetime:
-            type: keyword
-          variant_origin:
-            type: keyword
-          variant_type:
-            type: keyword
-          zygosity:
-            type: keyword
-        type: nested
-      pancreatitis_onset_year:
-        type: long
-      progression_or_recurrence:
-        type: keyword
-      progression_or_recurrence_anatomic_site:
-        type: keyword
-      progression_or_recurrence_type:
-        type: keyword
-      reflux_treatment_type:
-        type: keyword
-      risk_factor:
-        type: keyword
-      risk_factor_treatment:
-        type: keyword
-      state:
-        type: keyword
-      submitter_id:
-        type: keyword
-      updated_datetime:
-        type: keyword
-      viral_hepatitis_serologies:
-        type: keyword
-      weight:
-        type: long
     type: nested
   index_date:
     type: keyword
@@ -817,10 +534,6 @@ properties:
         type: nested
       biospecimen_anatomic_site:
         type: keyword
-      biospecimen_laterality:
-        type: keyword
-      catalog_reference:
-        type: keyword
       composition:
         type: keyword
       created_datetime:
@@ -833,28 +546,20 @@ properties:
         type: long
       diagnosis_pathologically_confirmed:
         type: keyword
-      distance_normal_to_tumor:
-        type: keyword
-      distributor_reference:
-        type: keyword
       freezing_method:
         type: keyword
-      growth_rate:
-        type: long
       initial_weight:
         type: long
       intermediate_dimension:
-        type: long
+        type: keyword
       is_ffpe:
         type: keyword
       longest_dimension:
-        type: long
+        type: keyword
       method_of_sample_procurement:
         type: keyword
       oct_embedded:
         type: keyword
-      passage_count:
-        type: long
       pathology_report_uuid:
         type: keyword
       portions:
@@ -931,22 +636,6 @@ properties:
                   concentration:
                     type: long
                   created_datetime:
-                    type: keyword
-                  no_matched_normal_low_pass_wgs:
-                    type: keyword
-                  no_matched_normal_targeted_sequencing:
-                    type: keyword
-                  no_matched_normal_wgs:
-                    type: keyword
-                  no_matched_normal_wxs:
-                    type: keyword
-                  selected_normal_low_pass_wgs:
-                    type: keyword
-                  selected_normal_targeted_sequencing:
-                    type: keyword
-                  selected_normal_wgs:
-                    type: keyword
-                  selected_normal_wxs:
                     type: keyword
                   source_center:
                     type: keyword
@@ -1180,15 +869,15 @@ properties:
       sample_type_id:
         type: keyword
       shortest_dimension:
-        type: long
+        type: keyword
       state:
         type: keyword
       submitter_id:
         type: keyword
       time_between_clamping_and_freezing:
-        type: long
+        type: keyword
       time_between_excision_and_freezing:
-        type: long
+        type: keyword
       tissue_type:
         type: keyword
       tumor_code:
@@ -1207,8 +896,6 @@ properties:
   submitter_aliquot_ids:
     type: keyword
   submitter_analyte_ids:
-    type: keyword
-  submitter_diagnosis_ids:
     type: keyword
   submitter_id:
     type: keyword

--- a/es-models/gdc_legacy_graph/descriptions.yaml
+++ b/es-models/gdc_legacy_graph/descriptions.yaml
@@ -9,45 +9,17 @@ _meta:
       specimen analyte.
     annotations.aliquot.analyte_type_id: A single letter code used to identify a type
       of molecular analyte.
-    annotations.aliquot.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     annotations.aliquot.concentration: Numeric value that represents the concentration
       of an analyte or aliquot extracted from the sample or sample portion, measured
       in milligrams per milliliter.
     annotations.aliquot.created_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    annotations.aliquot.no_matched_normal_low_pass_wgs: There will be no matched normal
-      low pass WGS aliquots for this case that can be used for variant calling purposes.
-      The GDC may elect to use a single tumor calling pipeline to process this data.
-    annotations.aliquot.no_matched_normal_targeted_sequencing: There will be no matched
-      normal Targeted Sequencing aliquots for this case that can be used for variant
-      calling purposes. The GDC may elect to use a single tumor calling pipeline to
-      process this data.
-    annotations.aliquot.no_matched_normal_wgs: There will be no matched normal WGS
-      aliquots for this case that can be used for variant calling purposes. The GDC
-      may elect to use a single tumor calling pipeline to process this data.
-    annotations.aliquot.no_matched_normal_wxs: There will be no matched normal WXS
-      aliquots for this case that can be used for variant calling purposes. The GDC
-      may elect to use a single tumor calling pipeline to process this data.
     annotations.aliquot.project_id: Unique ID for any specific defined piece of work
       that is undertaken or attempted to meet a single requirement.
-    annotations.aliquot.selected_normal_low_pass_wgs: Denotes which low-pass WGS normal
-      aliquot the submitter prefers to use for variant calling. Only one normal per
-      experimental strategy per case can be selected.
-    annotations.aliquot.selected_normal_targeted_sequencing: Denotes which targeted_sequencing
-      normal aliquot the submitter prefers to use for variant calling. Only one normal
-      per experimental strategy per case can be selected.
-    annotations.aliquot.selected_normal_wgs: Denotes which WGS normal aliquot the
-      submitter prefers to use for variant calling. Only one normal per experimental
-      strategy per case can be selected.
-    annotations.aliquot.selected_normal_wxs: Denotes which WXS normal aliquot the
-      submitter prefers to use for variant calling. Only one normal per experimental
-      strategy per case can be selected.
     annotations.aliquot.source_center: Name of the center that provided the item.
     annotations.aliquot.state: The current state of the object.
-    annotations.aliquot.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.aliquot.submitter_id: The legacy barcode used before prior to the
+      use UUIDs. For TCGA this is bcraliquotbarcode.
     annotations.aliquot.updated_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.analyte.a260_a280_ratio: Numeric value that represents the sample
@@ -60,10 +32,8 @@ _meta:
       specimen analyte.
     annotations.analyte.analyte_type_id: A single letter code used to identify a type
       of molecular analyte.
-    annotations.analyte.analyte_volume: The volume in microliters (ul) of the aliquot(s)
+    annotations.analyte.analyte_volume: The volume in microliters (ml) of the analyte(s)
       derived from the analyte(s) shipped for sequencing and characterization.
-    annotations.analyte.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     annotations.analyte.concentration: Numeric value that represents the concentration
       of an analyte or aliquot extracted from the sample or sample portion, measured
       in milligrams per milliliter.
@@ -79,15 +49,12 @@ _meta:
     annotations.analyte.spectrophotometer_method: Name of the method used to determine
       the concentration of purified nucleic acid within a solution.
     annotations.analyte.state: The current state of the object.
-    annotations.analyte.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.analyte.submitter_id: The legacy barcode used before prior to the
+      use UUIDs, varies by project. For TCGA this is bcranalytebarcode.
     annotations.analyte.updated_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.analyte.well_number: Numeric value that represents the the well location
       within a plate for the analyte or aliquot from the sample.
-    annotations.annotation.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
     annotations.annotation.created_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.annotation.error_type: null
@@ -99,60 +66,40 @@ _meta:
       work that is undertaken or attempted to meet a single requirement.
     annotations.annotation.state: The current state of the object.
     annotations.annotation.state_comment: null
-    annotations.annotation.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
+    annotations.annotation.submitter_id: null
     annotations.annotation.updated_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    annotations.case.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     annotations.case.created_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.case.days_to_lost_to_followup: The number of days between the date
       used for index and to the date the patient was lost to follow-up.
-    annotations.case.disease_type: The text term used to describe the type of malignant
-      disease, as categorized by the World Health Organization's (WHO) International
-      Classification of Diseases for Oncology (ICD-O).
-    annotations.case.index_date: The text term used to describe the reference or anchor
-      date used when for date obfuscation, where a single date is obscurred by creating
-      one or more date ranges in relation to this date.
-    annotations.case.lost_to_followup: The yes/no/unknown indicator used to describe
-      whether a patient was unable to be contacted or seen for follow-up information.
-    annotations.case.primary_site: The text term used to describe the primary site
-      of disease, as categorized by the World Health Organization's (WHO) International
-      Classification of Diseases for Oncology (ICD-O). This categorization groups
-      cases into general categories. Reference tissue_or_organ_of_origin on the diagnosis
-      node for more specific primary sites of disease.
+    annotations.case.disease_type: Full name for the project.
+    annotations.case.index_date: The reference or anchor date used during date obfuscation,
+      where a single date is obscurred by creating one or more date ranges in relation
+      to this date.
+    annotations.case.lost_to_followup: A yes/no indicator related to whether a patient
+      was unable to be contacted for follow-up.
+    annotations.case.primary_site: Primary site for the project.
     annotations.case.project_id: Unique ID for any specific defined piece of work
       that is undertaken or attempted to meet a single requirement.
     annotations.case.state: The current state of the object.
-    annotations.case.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.case.submitter_id: null
     annotations.case.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    annotations.file.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     annotations.file.created_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.file.error_type: Type of error for the data file object.
-    annotations.file.file_name: The name (or part of a name) of a file (of any type).
-    annotations.file.file_size: The size of the data file (object) in bytes.
+    annotations.file.file_name: The file (object) name
+    annotations.file.file_size: The size file (object) in bytes
     annotations.file.file_state: The current state of the data file object.
-    annotations.file.md5sum: The 128-bit hash value expressed as a 32 digit hexadecimal
-      number (in lower case) used as a file's digital fingerprint.
-    annotations.file.project_id: Unique ID for any specific defined piece of work
-      that is undertaken or attempted to meet a single requirement.
+    annotations.file.md5sum: The MD5 hash of this file
+    annotations.file.project_id: null
     annotations.file.state: The current state of the object.
     annotations.file.state_comment: Optional comment about why the file is in the
       current state, mainly for invalid state.
-    annotations.file.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.file.submitter_id: The file id assigned by the submitter
     annotations.file.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    annotations.portion.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     annotations.portion.created_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.portion.creation_datetime: The datetime of portion creation encoded
@@ -164,24 +111,18 @@ _meta:
     annotations.portion.project_id: Unique ID for any specific defined piece of work
       that is undertaken or attempted to meet a single requirement.
     annotations.portion.state: The current state of the object.
-    annotations.portion.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.portion.submitter_id: The legacy barcode used before prior to the
+      use UUIDs, varies by project. For TCGA this is bcrportionbarcode.
     annotations.portion.updated_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.portion.weight: Numeric value that represents the sample portion weight,
       measured in milligrams.
-    annotations.project.awg_review: Indicates that the project is an AWG project.
     annotations.project.code: Project code
     annotations.project.dbgap_accession_number: The dbgap accession number for the
       project.
     annotations.project.disease_type: Full name for the project
-    annotations.project.in_review: Indicates that the project is under review by the
-      submitter. Upload and data modification is disabled.
     annotations.project.intended_release_date: Tracks a Project's intended release
       date.
-    annotations.project.is_legacy: Indicates whether a project will appear in the
-      Legacy Archive.
     annotations.project.name: Display name for the project
     annotations.project.primary_site: Primary site for the project
     annotations.project.program.dbgap_accession_number: The dbgap accession number
@@ -189,24 +130,16 @@ _meta:
     annotations.project.program.name: Full name/title of the program.
     annotations.project.releasable: A project can only be released by the user when
       `releasable` is true.
-    annotations.project.release_requested: User requests that the GDC release the
-      project. Release can only be requested if the project is releasable.
-    annotations.project.released: To release a project is to tell the GDC to include
-      all submitted entities in the next GDC index.
-    annotations.project.request_submission: Indicates that the user has requested
-      submission to the GDC for harmonization.
-    annotations.project.state: The possible states a project can be in.  All but `open`
-      are equivalent to some type of locked state.
-    annotations.project.submission_enabled: Indicates if submission to a project is
-      allowed.
-    annotations.sample.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
+    annotations.project.released: 'To release a project is to tell the GDC to include
+      all submitted
+
+      entities in the next GDC index.'
+    annotations.project.state: 'The possible states a project can be in.  All but
+      `open` are
+
+      equivalent to some type of locked state.'
     annotations.sample.biospecimen_anatomic_site: Text term that represents the name
       of the primary disease site of the submitted tumor sample.
-    annotations.sample.biospecimen_laterality: For tumors in paired organs, designates
-      the side on which the specimen was obtained.
-    annotations.sample.catalog_reference: HCMI catalog reference number for cancer
-      model.
     annotations.sample.composition: Text term that represents the cellular composition
       of the sample.
     annotations.sample.created_datetime: A combination of date and time of day in
@@ -218,19 +151,9 @@ _meta:
       number of days.
     annotations.sample.days_to_sample_procurement: The number of days from the date
       the patient was diagnosed to the date of the procedure that produced the sample.
-    annotations.sample.diagnosis_pathologically_confirmed: The histologic description
-      of tissue or cells confirmed by a pathology review of frozen or formalin fixed
-      slide(s) completed after the diagnostic pathology review of the tumor sample
-      used to extract analyte(s).
-    annotations.sample.distance_normal_to_tumor: Text term to signify the distance
-      between the tumor tissue and the normal control tissue that was procured for
-      matching normal DNA.
-    annotations.sample.distributor_reference: Distributor reference number for cancer
-      model.
+    annotations.sample.diagnosis_pathologically_confirmed: null
     annotations.sample.freezing_method: Text term that represents the method used
       for freezing the sample.
-    annotations.sample.growth_rate: Rate at which the model grows, measured as hours
-      to time to split.
     annotations.sample.initial_weight: Numeric value that represents the initial weight
       of the sample, measured in milligrams.
     annotations.sample.intermediate_dimension: null
@@ -241,13 +164,10 @@ _meta:
       sample used to extract analyte(s).
     annotations.sample.oct_embedded: Indicator of whether or not the sample was embedded
       in Optimal Cutting Temperature (OCT) compound.
-    annotations.sample.passage_count: Number of passages (splits) between the original
-      tissue and this model.
     annotations.sample.pathology_report_uuid: UUID of the related pathology report.
     annotations.sample.preservation_method: Text term that represents the method used
       to preserve the sample.
-    annotations.sample.project_id: Unique ID for any specific defined piece of work
-      that is undertaken or attempted to meet a single requirement.
+    annotations.sample.project_id: null
     annotations.sample.sample_type: Text term to describe the source of a biospecimen
       used for a laboratory test.
     annotations.sample.sample_type_id: The accompanying sample type id for the sample
@@ -255,9 +175,8 @@ _meta:
     annotations.sample.shortest_dimension: Numeric value that represents the shortest
       dimension of the sample, measured in millimeters.
     annotations.sample.state: The current state of the object.
-    annotations.sample.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.sample.submitter_id: The legacy barcode used before prior to the use
+      UUIDs, varies by project. For TCGA this is bcrsamplebarcode.
     annotations.sample.time_between_clamping_and_freezing: Numeric representation
       of the elapsed time between the surgical clamping of blood supply and freezing
       of the sample, measured in minutes.
@@ -273,8 +192,6 @@ _meta:
       in the tumor specimen as related to a specific timepoint.
     annotations.sample.updated_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    annotations.slide.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     annotations.slide.created_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     annotations.slide.number_proliferating_cells: Numeric value that represents the
@@ -303,20 +220,17 @@ _meta:
       of reactive cells that are present in a malignant tumor sample or specimen but
       are not malignant such as fibroblasts, vascular structures, etc.
     annotations.slide.percent_tumor_cells: Numeric value that represents the percentage
-      of infiltration by tumor cells in a sample.
+      of infiltration by granulocytes in a sample.
     annotations.slide.percent_tumor_nuclei: Numeric value to represent the percentage
       of tumor nuclei in a malignant neoplasm sample or specimen.
     annotations.slide.project_id: Unique ID for any specific defined piece of work
       that is undertaken or attempted to meet a single requirement.
     annotations.slide.section_location: Tissue source of the slide.
     annotations.slide.state: The current state of the object.
-    annotations.slide.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    annotations.slide.submitter_id: The legacy barcode used before prior to the use
+      UUIDs, varies by project. For TCGA, this is bcrslidebarcode.
     annotations.slide.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.annotations.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     cases.annotations.category: Top level characterization of the annotation.
     cases.annotations.classification: Top level classification of the annotation.
     cases.annotations.created_datetime: A combination of date and time of day in the
@@ -333,56 +247,35 @@ _meta:
       that is undertaken or attempted to meet a single requirement.
     cases.annotations.state: The current state of the object.
     cases.annotations.status: Status of the annotation.
-    cases.annotations.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    cases.annotations.submitter_id: null
     cases.annotations.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.case.batch_id: GDC submission batch indicator. It is unique within the context
-      of a project.
     cases.case.created_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.case.days_to_lost_to_followup: The number of days between the date used
       for index and to the date the patient was lost to follow-up.
-    cases.case.disease_type: The text term used to describe the type of malignant
-      disease, as categorized by the World Health Organization's (WHO) International
-      Classification of Diseases for Oncology (ICD-O).
-    cases.case.index_date: The text term used to describe the reference or anchor
-      date used when for date obfuscation, where a single date is obscurred by creating
-      one or more date ranges in relation to this date.
-    cases.case.lost_to_followup: The yes/no/unknown indicator used to describe whether
-      a patient was unable to be contacted or seen for follow-up information.
-    cases.case.primary_site: The text term used to describe the primary site of disease,
-      as categorized by the World Health Organization's (WHO) International Classification
-      of Diseases for Oncology (ICD-O). This categorization groups cases into general
-      categories. Reference tissue_or_organ_of_origin on the diagnosis node for more
-      specific primary sites of disease.
+    cases.case.disease_type: Full name for the project.
+    cases.case.index_date: The reference or anchor date used during date obfuscation,
+      where a single date is obscurred by creating one or more date ranges in relation
+      to this date.
+    cases.case.lost_to_followup: A yes/no indicator related to whether a patient was
+      unable to be contacted for follow-up.
+    cases.case.primary_site: Primary site for the project.
     cases.case.project_id: Unique ID for any specific defined piece of work that is
       undertaken or attempted to meet a single requirement.
     cases.case.state: The current state of the object.
-    cases.case.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
+    cases.case.submitter_id: null
     cases.case.updated_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.demographic.age_at_index: The patient's age (in years) on the reference
-      or anchor date date used during date obfuscation.
-    cases.demographic.age_is_obfuscated: The age of the patient has been modified
-      for compliance reasons. The actual age differs from what is reported. Other
-      date intervals for this patient may also be modified.
-    cases.demographic.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     cases.demographic.cause_of_death: Text term to identify the cause of death for
       a patient.
-    cases.demographic.cause_of_death_source: The text term used to describe the source
-      used to determine the patient's cause of death.
     cases.demographic.created_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.demographic.days_to_birth: Number of days between the date used for index
-      and the date from a person's date of birth represented as a calculated negative
+    cases.demographic.days_to_birth: Time interval from a person's date of birth to
+      the date of initial pathologic diagnosis, represented as a calculated negative
       number of days.
-    cases.demographic.days_to_death: Number of days between the date used for index
-      and the date from a person's date of death represented as a calculated number
+    cases.demographic.days_to_death: Time interval from a person's date of death to
+      the date of initial pathologic diagnosis, represented as a calculated number
       of days.
     cases.demographic.ethnicity: An individual's self-described social and cultural
       grouping, specifically whether an individual describes themselves as Hispanic
@@ -392,10 +285,6 @@ _meta:
       as the assemblage of properties that distinguish people on the basis of their
       societal roles. [Explanatory Comment 1: Identification of gender is based upon
       self-report and may come from a form, questionnaire, interview, etc.]'
-    cases.demographic.occupation_duration_years: The number of years a patient worked
-      in a specific occupation.
-    cases.demographic.premature_at_birth: The yes/no/unknown indicator used to describe
-      whether the patient was premature (less than 37 weeks gestation) at birth.
     cases.demographic.project_id: Unique ID for any specific defined piece of work
       that is undertaken or attempted to meet a single requirement.
     cases.demographic.race: An arbitrary classification of a taxonomic group that
@@ -406,16 +295,11 @@ _meta:
       defined by the U.S. Office of Management and Business and used by the U.S. Census
       Bureau.
     cases.demographic.state: The current state of the object.
-    cases.demographic.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    cases.demographic.submitter_id: null
     cases.demographic.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.demographic.vital_status: The survival state of the person registered on
       the protocol.
-    cases.demographic.weeks_gestation_at_birth: Numeric value used to describe the
-      number of weeks starting  from the approximate date of the biological mother's
-      last menstrual period and ending with the birth of the patient.
     cases.demographic.year_of_birth: Numeric value to represent the calendar year
       in which an individual was born.
     cases.demographic.year_of_death: Numeric value to represent the year of the death
@@ -446,194 +330,83 @@ _meta:
     cases.diagnoses.ajcc_pathologic_t: Code of pathological T (primary tumor) to define
       the size or contiguous extension of the primary tumor (T), using staging criteria
       from the American Joint Committee on Cancer (AJCC).
-    cases.diagnoses.ajcc_staging_system_edition: The text term used to describe the
-      version or edition of the American Joint Committee on Cancer Staging Handbooks,
-      a publication by the group formed for the purpose of developing a system of
-      staging for cancer that is acceptable to the American medical profession and
-      is compatible with other accepted classifications.
-    cases.diagnoses.anaplasia_present: Yes/no/unknown/not reported indicator used
-      to describe whether anaplasia was present at the time of diagnosis.
-    cases.diagnoses.anaplasia_present_type: The text term used to describe the morphologic
-      findings indicating the presence of a malignant cellular infiltrate characterized
-      by the presence of large pleomorphic cells, necrosis, and high mitotic activity
-      in a tissue sample.
     cases.diagnoses.ann_arbor_b_symptoms: Text term to signify whether lymphoma B-symptoms
       are present as noted in the patient's medical record.
-    cases.diagnoses.ann_arbor_clinical_stage: The text term used to describe the clinical
-      classification of lymphoma, as defined by the Ann Arbor Lymphoma Staging System.
+    cases.diagnoses.ann_arbor_clinical_stage: The classification of the clinically
+      confirmed anatomic disease extent of lymphoma (Hodgkin's and Non-Hodgkins) based
+      on the Ann Arbor Staging System.
     cases.diagnoses.ann_arbor_extranodal_involvement: Indicator that identifies whether
       a patient with malignant lymphoma has lymphomatous involvement of an extranodal
       site.
-    cases.diagnoses.ann_arbor_pathologic_stage: The text term used to describe the
-      pathologic classification of lymphoma, as defined by the Ann Arbor Lymphoma
-      Staging System.
-    cases.diagnoses.annotations.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
-    cases.diagnoses.annotations.category: Top level characterization of the annotation.
-    cases.diagnoses.annotations.classification: Top level classification of the annotation.
-    cases.diagnoses.annotations.created_datetime: A combination of date and time of
-      day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.diagnoses.annotations.creator: Name of the person or entity responsible
-      for the creation of the annotation.
-    cases.diagnoses.annotations.legacy_created_datetime: A combination of date and
-      time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.diagnoses.annotations.legacy_updated_datetime: A combination of date and
-      time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.diagnoses.annotations.notes: Open entry for any further description or characterization
-      of the data.
-    cases.diagnoses.annotations.project_id: Unique ID for any specific defined piece
-      of work that is undertaken or attempted to meet a single requirement.
-    cases.diagnoses.annotations.state: The current state of the object.
-    cases.diagnoses.annotations.status: Status of the annotation.
-    cases.diagnoses.annotations.submitter_id: A project-specific identifier for a
-      node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
-    cases.diagnoses.annotations.updated_datetime: A combination of date and time of
-      day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.diagnoses.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
+    cases.diagnoses.ann_arbor_pathologic_stage: The classification of the pathologically
+      confirmed anatomic disease extent of lymphoma (Hodgkin's and Non-Hodgkins) based
+      on the Ann Arbor Staging System.
     cases.diagnoses.best_overall_response: The best improvement achieved throughout
       the entire course of protocol treatment.
-    cases.diagnoses.breslow_thickness: The number that describes the distance, in
-      millimeters, between the upper layer of the epidermis and the deepest point
-      of tumor penetration.
     cases.diagnoses.burkitt_lymphoma_clinical_variant: Burkitt's lymphoma categorization
       based on clinical features that differ from other forms of the same disease.
-    cases.diagnoses.child_pugh_classification: The text term used to describe the
-      classification used in the prognosis of chronic liver disease, mainly cirrhosis.
-    cases.diagnoses.circumferential_resection_margin: Numeric value used to describe
-      the non-peritonealised bare area of rectum, comprising anterior and posterior
-      segments, when submitted as a surgical specimen resulting from excision of cancer
-      of the rectum.
+    cases.diagnoses.cause_of_death: Text term to identify the cause of death for a
+      patient.
+    cases.diagnoses.circumferential_resection_margin: A value in millimeters indicating
+      the measured length between a malignant lesion of the colon or rectum and the
+      nearest radial (or circumferential) border of tissue removed during cancer surgery.
     cases.diagnoses.classification_of_tumor: Text that describes the kind of disease
       present in the tumor specimen as related to a specific timepoint.
-    cases.diagnoses.cog_liver_stage: The text term used to describe the staging classification
-      of liver tumors, as defined by the Children's Oncology Group (COG). This staging
-      system specifically describes the extent of the primary tumor prior to treatment.
-    cases.diagnoses.cog_neuroblastoma_risk_group: Text term that represents the categorization
-      of patients on the basis of prognostic factors per a system developed by Children's
-      Oncology Group (COG). Risk level is used to assign treatment intensity.
-    cases.diagnoses.cog_renal_stage: The text term used to describe the staging classification
-      of renal tumors, as defined by the Children's Oncology Group (COG).
-    cases.diagnoses.cog_rhabdomyosarcoma_risk_group: Text term used to describe the
-      classification of rhabdomyosarcoma, as defined by the Children's Oncology Group
-      (COG).
+    cases.diagnoses.colon_polyps_history: Yes/No indicator to describe if the subject
+      had a previous history of colon polyps as noted in the history/physical or previous
+      endoscopic report (s).
     cases.diagnoses.created_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.diagnoses.days_to_best_overall_response: Number of days between the date
-      used for index and the date of the patient was thought to have the best overall
-      response to their disease.
+      used for index and the date of the patient's best overall response.
+    cases.diagnoses.days_to_birth: Time interval from a person's date of birth to
+      the date of initial pathologic diagnosis, represented as a calculated negative
+      number of days.
+    cases.diagnoses.days_to_death: Time interval from a person's date of death to
+      the date of initial pathologic diagnosis, represented as a calculated number
+      of days.
     cases.diagnoses.days_to_diagnosis: Number of days between the date used for index
-      and the date the patient was diagnosed with the malignant disease.
+      and the date of diagnosis.
+    cases.diagnoses.days_to_hiv_diagnosis: Time interval from the date of the initial
+      pathologic diagnosis to the date of human immunodeficiency diagnosis, represented
+      as a calculated number of days.
     cases.diagnoses.days_to_last_follow_up: Time interval from the date of last follow
       up to the date of initial pathologic diagnosis, represented as a calculated
       number of days.
     cases.diagnoses.days_to_last_known_disease_status: Time interval from the date
       of last follow up to the date of initial pathologic diagnosis, represented as
       a calculated number of days.
+    cases.diagnoses.days_to_new_event: Time interval from the date of new tumor event
+      including progression, recurrence and new primary malignacies to the date of
+      initial pathologic diagnosis, represented as a calculated number of days.
     cases.diagnoses.days_to_recurrence: Number of days between the date used for index
-      and the date the patient's disease recurred.
-    cases.diagnoses.enneking_msts_grade: The text term used to describe the surgical
-      grade of the musculoskeletal sarcoma, using the Enneking staging system approved
-      by the Musculoskeletal Tumor Society (MSTS).
-    cases.diagnoses.enneking_msts_metastasis: Text term and code that represents the
-      metastatic stage of the musculoskeletal sarcoma, using the Enneking staging
-      system approved by the Musculoskeletal Tumor Society (MSTS).
-    cases.diagnoses.enneking_msts_stage: Text term used to describe the stage of the
-      musculoskeletal sarcoma, using the Enneking staging system approved by the Musculoskeletal
-      Tumor Society (MSTS).
-    cases.diagnoses.enneking_msts_tumor_site: Text term and code that represents the
-      tumor site of the musculoskeletal sarcoma, using the Enneking staging system
-      approved by the Musculoskeletal Tumor Society (MSTS).
-    cases.diagnoses.esophageal_columnar_dysplasia_degree: Text term to describe the
-      amount of dysplasia found within the benign esophageal columnar mucosa.
-    cases.diagnoses.esophageal_columnar_metaplasia_present: The yes/no/unknown indicator
-      used to describe whether esophageal columnar metaplasia was determined to be
-      present.
+      and the date the patient was diagnosed with a recurrent malignancy.
     cases.diagnoses.figo_stage: The extent of a cervical or endometrial cancer within
       the body, especially whether the disease has spread from the original site to
       other parts of the body, as described by the International Federation of Gynecology
       and Obstetrics (FIGO) stages.
-    cases.diagnoses.first_symptom_prior_to_diagnosis: Text term used to describe the
-      patient's first symptom experienced prior to diagnosis and thought to be related
-      to the disease.
-    cases.diagnoses.gastric_esophageal_junction_involvement: The yes/no/unknown/not
-      reported indicator used to describe whether the tumor is located across the
-      gastroesophageal junction.
-    cases.diagnoses.gleason_grade_group: The text term used to describe the overall
-      grouping of grades defined by the Gleason grading classification, which is used
-      to determine the aggressiveness of prostate cancer. Note that this grade describes
-      the entire prostatectomy specimen and is not specific to the sample used for
-      sequencing.
-    cases.diagnoses.goblet_cells_columnar_mucosa_present: The yes/no/unknown indicator
-      used to describe whether goblet cells were determined to be present in the esophageal
-      columnar mucosa.
-    cases.diagnoses.gross_tumor_weight: Numeric value used to describe the gross pathologic
-      tumor weight, measured in grams.
-    cases.diagnoses.icd_10_code: Alphanumeric value used to describe the  disease
-      code from the tenth version of the International Classification of Disease (ICD-10).
-    cases.diagnoses.igcccg_stage: The text term used to describe the International
-      Germ Cell Cancer Collaborative Group (IGCCCG), a grouping used to further classify
-      metastatic testicular tumors.
-    cases.diagnoses.inpc_grade: Text term used to describe the classification of neuroblastic
-      differentiation within neuroblastoma tumors, as defined by the International
-      Neuroblastoma Pathology Classification (INPC).
-    cases.diagnoses.inpc_histologic_group: The text term used to describe the classification
-      of neuroblastomas distinguishing between favorable and unfavorable histologic
-      groups. The histologic score, defined by the International Neuroblastoma Pathology
-      Classification (INPC), is based on age, mitosis-karyorrhexis index (MKI), stromal
-      content and degree of tumor cell differentiation.
-    cases.diagnoses.inrg_stage: The text term used to describe the staging classification
-      of neuroblastic tumors, as defined by the International Neuroblastoma Risk Group
-      (INRG).
-    cases.diagnoses.inss_stage: Text term used to describe the staging classification
-      of neuroblastic tumors, as defined by the International Neuroblastoma Staging
-      System (INSS).
-    cases.diagnoses.international_prognostic_index: The text term used to describe
-      the International Prognostic Index, which classifies the prognosis of patients
-      with aggressive non-Hodgkin's lymphoma.
-    cases.diagnoses.irs_group: Text term used to describe the classification of rhabdomyosarcoma
-      tumors, as defined by the Intergroup Rhabdomyosarcoma Study (IRS).
-    cases.diagnoses.irs_stage: The text term used to describe the classification of
-      rhabdomyosarcoma tumors, as defined by the Intergroup Rhabdomyosarcoma Study
-      (IRS).
-    cases.diagnoses.ishak_fibrosis_score: The text term used to describe the classification
-      of the histopathologic degree of liver damage.
+    cases.diagnoses.hiv_positive: Text term to signify whether a physician has diagnosed
+      HIV infection in a patient.
+    cases.diagnoses.hpv_positive_type: Text classification to represent the strain
+      or type of human papillomavirus identified in an individual.
+    cases.diagnoses.hpv_status: The findings of the oncogenic HPV.
     cases.diagnoses.iss_stage: The multiple myeloma disease stage at diagnosis.
-    cases.diagnoses.largest_extrapelvic_peritoneal_focus: The text term used to describe
-      the diameter of the largest focus originating outside of the pelvic peritoneal
-      region.
     cases.diagnoses.last_known_disease_status: Text term that describes the last known
       state or condition of an individual's neoplasm.
     cases.diagnoses.laterality: For tumors in paired organs, designates the side on
       which the cancer originates.
+    cases.diagnoses.ldh_level_at_diagnosis: The 2 decimal place numeric laboratory
+      value measured, assigned or computed related to the assessment of lactate dehydrogenase
+      in a specimen.
+    cases.diagnoses.ldh_normal_range_upper: The top value of the range of statistical
+      characteristics that are supposed to represent accepted standard, non-pathological
+      pattern for lactate dehydrogenase (units not specified).
     cases.diagnoses.lymph_nodes_positive: The number of lymph nodes involved with
       disease as determined by pathologic examination.
-    cases.diagnoses.lymph_nodes_tested: The number of lymph nodes tested to determine
-      whether lymph nodes were  involved with disease as determined by a pathologic
-      examination.
     cases.diagnoses.lymphatic_invasion_present: A yes/no indicator to ask if small
       or thin-walled vessel invasion is present, indicating lymphatic involvement
-    cases.diagnoses.masaoka_stage: The text term used to describe the Masaoka staging
-      system, a classification that defines prognostic indicators for thymic malignancies
-      and predicts tumor recurrence.
-    cases.diagnoses.medulloblastoma_molecular_classification: The text term used to
-      describe the classification of medulloblastoma tumors based on molecular features.
-    cases.diagnoses.metastasis_at_diagnosis: The text term used to describe the extent
-      of metastatic disease present at diagnosis.
-    cases.diagnoses.metastasis_at_diagnosis_site: Text term to identify an anatomic
-      site in which metastatic disease involvement is found.
-    cases.diagnoses.method_of_diagnosis: Text term used to describe the method used
-      to confirm the patients malignant diagnosis.
-    cases.diagnoses.micropapillary_features: The yes/no/unknown indicator used to
-      describe whether micropapillary features were determined to be present.
-    cases.diagnoses.mitosis_karyorrhexis_index: Text term that represents the component
-      of the International Neuroblastoma Pathology Classification (INPC) for mitosis-karyorrhexis
-      index (MKI).
-    cases.diagnoses.mitotic_count: The number of mitoses identified under the microscope
-      in tumors. The method of counting varies, according to the specific tumor examined.
-      Usually, the mitotic count is determined based on the number of mitoses per
-      high power field (40X) or 10 high power fields.
+    cases.diagnoses.method_of_diagnosis: The method used to initially the patient's
+      diagnosis.
     cases.diagnoses.morphology: The third edition of the International Classification
       of Diseases for Oncology, published in 2000 used principally in tumor and cancer
       registries for coding the site (topography) and the histology (morphology) of
@@ -642,117 +415,74 @@ _meta:
       In pathology, the microscopic process of identifying normal and abnormal morphologic
       characteristics in tissues, by employing various cytochemical and immunocytochemical
       stains. A system of numbered categories for representation of data.
-    cases.diagnoses.non_nodal_regional_disease: The text term used to describe whether
-      the patient had non-nodal regional disease.
-    cases.diagnoses.non_nodal_tumor_deposits: The yes/no/unknown indicator used to
-      describe the presence of tumor deposits in the pericolic or perirectal fat or
-      in adjacent mesentery away from the leading edge of the tumor.
-    cases.diagnoses.ovarian_specimen_status: The text term used to describe the physical
-      condition of the involved ovary.
-    cases.diagnoses.ovarian_surface_involvement: The text term that describes whether
-      the surface tissue (outer boundary) of the ovary shows evidence of involvement
-      or presence of cancer.
-    cases.diagnoses.percent_tumor_invasion: The percentage of tumor cells spread locally
-      in a malignant neoplasm through infiltration or destruction of adjacent tissue.
+    cases.diagnoses.new_event_anatomic_site: Text term to specify the anatomic location
+      of the return of tumor after treatment.
+    cases.diagnoses.new_event_type: Text term to identify a new tumor event.
+    cases.diagnoses.overall_survival: Number of days between the date used for index
+      and the patient's date of death or the date the patient was last known to be
+      alive.
     cases.diagnoses.perineural_invasion_present: a yes/no indicator to ask if perineural
       invasion or infiltration of tumor or cancer is present.
-    cases.diagnoses.peripancreatic_lymph_nodes_positive: Enumerated numeric value
-      or range of values used to describe the number of peripancreatic lymph nodes
-      determined to be positive.
-    cases.diagnoses.peripancreatic_lymph_nodes_tested: The total number of peripancreatic
-      lymph nodes tested for the presence of pancreatic cancer cells.
-    cases.diagnoses.peritoneal_fluid_cytological_status: The text term used to describe
-      the malignant status of the peritoneal fluid determined by cytologic testing.
-    cases.diagnoses.primary_diagnosis: Text term used to describe the patient's histologic
-      diagnosis, as described by the World Health Organization's (WHO) International
-      Classification of Diseases for Oncology (ICD-O).
-    cases.diagnoses.primary_gleason_grade: The text term used to describe the primary
-      Gleason score, which describes the pattern of cells making up the largest area
-      of the tumor. The primary and secondary Gleason pattern grades are combined
-      to determine the patient's Gleason grade group, which is used to determine the
-      aggresiveness of prostate cancer. Note that this grade describes the entire
-      prostatectomy specimen and is not specific to the sample used for sequencing.
-    cases.diagnoses.prior_malignancy: The yes/no/unknown indicator used to describe
-      the patient's history of prior cancer diagnosis.
+    cases.diagnoses.primary_diagnosis: Text term for the structural pattern of cancer
+      cells used to define a microscopic diagnosis.
+    cases.diagnoses.prior_malignancy: Text term to describe the patient's history
+      of prior cancer diagnosis and the spatial location of any previous cancer occurrence.
     cases.diagnoses.prior_treatment: A yes/no/unknown/not applicable indicator related
       to the administration of therapeutic agents received before the body specimen
       was collected.
+    cases.diagnoses.progression_free_survival: Number of days between the date used
+      for index and the first date the patient is known to be free of disease progression.
+    cases.diagnoses.progression_free_survival_event: The event used to define the
+      patient's disease progression.
     cases.diagnoses.progression_or_recurrence: Yes/No/Unknown indicator to identify
       whether a patient has had a new tumor event after initial treatment.
     cases.diagnoses.project_id: Unique ID for any specific defined piece of work that
       is undertaken or attempted to meet a single requirement.
     cases.diagnoses.residual_disease: Text terms to describe the status of a tissue
       margin following surgical resection.
-    cases.diagnoses.secondary_gleason_grade: The text term used to describe the secondary
-      Gleason score, which describes the pattern of cells making up the second largest
-      area of the tumor. The primary and secondary Gleason pattern grades are combined
-      to determine the patient's Gleason grade group, which is used to determine the
-      aggresiveness of prostate cancer. Note that this grade describes the entire
-      prostatectomy specimen and is not specific to the sample used for sequencing.
-    cases.diagnoses.site_of_resection_or_biopsy: The text term used to describe the
-      anatomic site of origin, of the patient's malignant disease, as described by
-      the World Health Organization's (WHO) International Classification of Diseases
-      for Oncology (ICD-O).
+    cases.diagnoses.site_of_resection_or_biopsy: The third edition of the International
+      Classification of Diseases for Oncology, published in 2000, used principally
+      in tumor and cancer registries for coding the site (topography) and the histology
+      (morphology) of neoplasms. The description of an anatomical region or of a body
+      part. Named locations of, or within, the body. A system of numbered categories
+      for representation of data.
     cases.diagnoses.state: The current state of the object.
-    cases.diagnoses.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
-    cases.diagnoses.supratentorial_localization: Text term to specify the location
-      of the supratentorial tumor.
-    cases.diagnoses.synchronous_malignancy: A yes/no/unknown indicator used to describe
-      whether the patient had an additional malignant diagnosis at the same time the
-      tumor used for sequencing was diagnosed. If both tumors were sequenced, both
-      tumors would have synchronous malignancies.
-    cases.diagnoses.tissue_or_organ_of_origin: The text term used to describe the
-      anatomic site of origin, of the patient's malignant disease, as described by
-      the World Health Organization's (WHO) International Classification of Diseases
-      for Oncology (ICD-O).
-    cases.diagnoses.treatments.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
+    cases.diagnoses.submitter_id: null
+    cases.diagnoses.tissue_or_organ_of_origin: Text term that describes the anatomic
+      site of the tumor or disease.
     cases.diagnoses.treatments.created_datetime: A combination of date and time of
       day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.diagnoses.treatments.days_to_treatment_end: Number of days between the date
-      used for index and the date the treatment ended.
-    cases.diagnoses.treatments.days_to_treatment_start: Number of days between the
-      date used for index and the date the treatment started.
-    cases.diagnoses.treatments.initial_disease_status: The text term used to describe
-      the status of the patient's malignancy when the treatment began.
+    cases.diagnoses.treatments.days_to_treatment: Number of days from date of initial
+      pathologic diagnosis that treatment began.
+    cases.diagnoses.treatments.days_to_treatment_end: Time interval from the date
+      of the initial pathologic diagnosis to the date of treatment end, represented
+      as a calculated number of days.
+    cases.diagnoses.treatments.days_to_treatment_start: Time interval from the date
+      of the initial pathologic diagnosis to the start of treatment, represented as
+      a calculated number of days.
     cases.diagnoses.treatments.project_id: Unique ID for any specific defined piece
       of work that is undertaken or attempted to meet a single requirement.
-    cases.diagnoses.treatments.regimen_or_line_of_therapy: The text term used to describe
-      the regimen or line of therapy.
+    cases.diagnoses.treatments.regimen_or_line_of_therapy: The name of a regimen or
+      line of therapy assigned to the patient.
     cases.diagnoses.treatments.state: The current state of the object.
-    cases.diagnoses.treatments.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
+    cases.diagnoses.treatments.submitter_id: null
     cases.diagnoses.treatments.therapeutic_agents: Text identification of the individual
-      agent(s) used as part of a treatment regimen.
+      agent(s) used as part of a prior treatment regimen.
     cases.diagnoses.treatments.treatment_anatomic_site: The anatomic site or field
       targeted by a treatment regimen or single agent therapy.
-    cases.diagnoses.treatments.treatment_effect: The text term used to describe the
-      pathologic effect a treatment(s) had on the tumor.
     cases.diagnoses.treatments.treatment_intent_type: Text term to identify the reason
       for the administration of a treatment regimen. [Manually-curated]
     cases.diagnoses.treatments.treatment_or_therapy: A yes/no/unknown/not applicable
-      indicator related to the administration of therapeutic agents received.
-    cases.diagnoses.treatments.treatment_outcome: Text term that describes the patient's
-      final outcome after the treatment was administered.
+      indicator related to the administration of therapeutic agents received before
+      the body specimen was collected.
+    cases.diagnoses.treatments.treatment_outcome: "Text term that describes the patient\xBF\
+      s final outcome after the treatment was administered."
     cases.diagnoses.treatments.treatment_type: Text term that describes the kind of
       treatment administered.
     cases.diagnoses.treatments.updated_datetime: A combination of date and time of
       day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.diagnoses.tumor_confined_to_organ_of_origin: The yes/no/unknown indicator
-      used to describe whether the tumor is confined to the organ where it originated
-      and did not spread to a proximal or distant location within the body.
-    cases.diagnoses.tumor_focality: The text term used to describe whether the patient's
-      disease originated in a single location or multiple locations.
     cases.diagnoses.tumor_grade: Numeric value to express the degree of abnormality
       of cancer cells, a measure of differentiation and aggressiveness.
-    cases.diagnoses.tumor_largest_dimension_diameter: Numeric value used to describe
-      the maximum diameter or dimension of the primary tumor, measured in centimeters.
-    cases.diagnoses.tumor_regression_grade: A numeric value used to measure therapeutic
-      response of the primary tumor and predict patient outcomes based on a three-point
-      tumor regression grading system.
     cases.diagnoses.tumor_stage: The extent of a cancer in the body. Staging is usually
       based on the size of the tumor, whether lymph nodes contain cancer, and whether
       the cancer has spread from the original site to other parts of the body. The
@@ -763,327 +493,81 @@ _meta:
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.diagnoses.vascular_invasion_present: The yes/no indicator to ask if large
       vessel or venous invasion was detected by surgery or presence in a tumor specimen.
-    cases.diagnoses.vascular_invasion_type: Text term that represents the type of
-      vascular tumor invasion.
-    cases.diagnoses.weiss_assessment_score: 'The text term used to describe the overall
-      Weiss assessment score, a commonly used assessment describing the malignancy
-      of adrenocortical tumors. The Weiss score is determined based on nine histological
-      criteria including the following: high nuclear grade, mitotic rate greater than
-      five per 50 high power fields (HPF), atypical mitotic figures, eosinophilic
-      tumor cell cytoplasm (greater than 75% tumor cells), diffuse architecture (greater
-      than 33% of tumor), necrosis, venous invasion, sinusoidal invasion, and capsular
-      invasion.'
-    cases.diagnoses.wilms_tumor_histologic_subtype: The text term used to describe
-      the classification of Wilms tumors distinguishing between favorable and unfavorable
-      histologic groups.
+    cases.diagnoses.vital_status: The survival state of the person registered on the
+      protocol.
     cases.diagnoses.year_of_diagnosis: Numeric value to represent the year of an individual's
       initial pathologic diagnosis of cancer.
-    cases.exposures.alcohol_days_per_week: Numeric value used to describe the average
-      number of days each week that a person consumes an alcoholic beverage.
-    cases.exposures.alcohol_drinks_per_day: Numeric value used to describe the average
-      number of alcoholic beverages  a person consumes per day.
     cases.exposures.alcohol_history: A response to a question that asks whether the
       participant has consumed at least 12 drinks of any kind of alcoholic beverage
       in their lifetime.
     cases.exposures.alcohol_intensity: Category to describe the patient's current
       level of alcohol use as self-reported by the patient.
-    cases.exposures.asbestos_exposure: The yes/no/unknown indicator used to describe
-      whether the patient was exposed to asbestos.
-    cases.exposures.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
-    cases.exposures.bmi: A calculated numerical quantity that represents an individual's
-      weight to height ratio.
+    cases.exposures.bmi: The body mass divided by the square of the body height expressed
+      in units of kg/m^2.
     cases.exposures.cigarettes_per_day: The average number of cigarettes smoked per
       day.
-    cases.exposures.coal_dust_exposure: The yes/no/unknown indicator used to describe
-      whether a patient was exposed to fine powder derived by the crushing of coal.
     cases.exposures.created_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.exposures.environmental_tobacco_smoke_exposure: The yes/no/unknown indicator
-      used to describe whether a patient was exposed to smoke that is emitted from
-      burning tobacco, including cigarettes, pipes, and cigars. This includes tobacco
-      smoke exhaled by smokers.
     cases.exposures.height: The height of the patient in centimeters.
     cases.exposures.pack_years_smoked: Numeric computed value to represent lifetime
       tobacco exposure defined as number of cigarettes smoked per day x number of
       years smoked divided by 20.
     cases.exposures.project_id: Unique ID for any specific defined piece of work that
       is undertaken or attempted to meet a single requirement.
-    cases.exposures.radon_exposure: The yes/no/unknown indicator used to describe
-      whether the patient was exposed to radon.
-    cases.exposures.respirable_crystalline_silica_exposure: The yes/no/unknown indicator
-      used to describe whether a patient was exposured to respirable crystalline silica,
-      a widespread, naturally occurring, crystalline metal oxide that consists of
-      different forms including quartz, cristobalite, tridymite, tripoli, ganister,
-      chert and novaculite.
-    cases.exposures.smoking_frequency: The text term used to generally decribe how
-      often the patient smokes.
     cases.exposures.state: The current state of the object.
-    cases.exposures.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
-    cases.exposures.time_between_waking_and_first_smoke: The text term used to describe
-      the approximate amount of time elapsed between the time the patient wakes up
-      in the morning to the time they smoke their first cigarette.
+    cases.exposures.submitter_id: null
     cases.exposures.tobacco_smoking_onset_year: The year in which the participant
       began smoking.
     cases.exposures.tobacco_smoking_quit_year: The year in which the participant quit
       smoking.
     cases.exposures.tobacco_smoking_status: Category describing current smoking status
       and smoking history as self-reported by a patient.
-    cases.exposures.type_of_smoke_exposure: The text term used to describe the patient's
-      specific type of smoke exposure.
-    cases.exposures.type_of_tobacco_used: The text term used to describe the specific
-      type of tobacco used by the patient.
     cases.exposures.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.exposures.weight: The weight of the patient measured in kilograms.
     cases.exposures.years_smoked: Numeric value (or unknown) to represent the number
       of years a person has been smoking.
-    cases.family_histories.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
     cases.family_histories.created_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.family_histories.project_id: Unique ID for any specific defined piece of
       work that is undertaken or attempted to meet a single requirement.
     cases.family_histories.relationship_age_at_diagnosis: The age (in years) when
       the patient's relative was first diagnosed.
-    cases.family_histories.relationship_gender: The text term used to describe the
-      gender of the patient's relative with a history of cancer.
-    cases.family_histories.relationship_primary_diagnosis: The text term used to describe
-      the malignant diagnosis of the patient's relative with a history of cancer.
+    cases.family_histories.relationship_gender: 'Text designations that identify gender.
+      Gender is described as the assemblage of properties that distinguish people
+      on the basis of their societal roles. [Explanatory Comment 1: Identification
+      of gender is based upon self-report and may come from a form, questionnaire,
+      interview, etc.]'
+    cases.family_histories.relationship_primary_diagnosis: Text term for the structural
+      pattern of cancer cells used to define a microscopic diagnosis.
     cases.family_histories.relationship_type: The subgroup that describes the state
       of connectedness between members of the unit of society organized around kinship
       ties.
-    cases.family_histories.relative_with_cancer_history: The yes/no/unknown indicator
-      used to describe whether any of the patient's relatives have a history of cancer.
-    cases.family_histories.relatives_with_cancer_history_count: The number of relatives
-      the patient has with a known history of cancer.
+    cases.family_histories.relative_with_cancer_history: Indicator to signify whether
+      or not an individual's biological relative has been diagnosed with another type
+      of cancer.
     cases.family_histories.state: The current state of the object.
-    cases.family_histories.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
+    cases.family_histories.submitter_id: null
     cases.family_histories.updated_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.files.batch_id: GDC submission batch indicator. It is unique within the
-      context of a project.
     cases.files.created_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.files.error_type: Type of error for the data file object.
-    cases.files.file_name: The name (or part of a name) of a file (of any type).
-    cases.files.file_size: The size of the data file (object) in bytes.
+    cases.files.file_name: The file (object) name
+    cases.files.file_size: The size file (object) in bytes
     cases.files.file_state: The current state of the data file object.
-    cases.files.md5sum: The 128-bit hash value expressed as a 32 digit hexadecimal
-      number (in lower case) used as a file's digital fingerprint.
-    cases.files.project_id: Unique ID for any specific defined piece of work that
-      is undertaken or attempted to meet a single requirement.
+    cases.files.md5sum: The MD5 hash of this file
+    cases.files.project_id: null
     cases.files.state: The current state of the object.
     cases.files.state_comment: Optional comment about why the file is in the current
       state, mainly for invalid state.
-    cases.files.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
+    cases.files.submitter_id: The file id assigned by the submitter
     cases.files.updated_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.follow_ups.adverse_event: Text that represents the Common Terminology Criteria
-      for Adverse Events low level term name for an adverse event.
-    cases.follow_ups.barretts_esophagus_goblet_cells_present: The yes/no/unknown indicator
-      used to describe whether goblet cells were determined to be present in a patient
-      diagnosed with Barrett's esophagus.
-    cases.follow_ups.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
-    cases.follow_ups.bmi: A calculated numerical quantity that represents an individual's
-      weight to height ratio.
-    cases.follow_ups.cause_of_response: The text term used to describe the suspected
-      cause or reason for the patient disease response.
-    cases.follow_ups.comorbidity: The text term used to describe a comorbidity disease,
-      which coexists with the patient's malignant disease.
-    cases.follow_ups.comorbidity_method_of_diagnosis: The text term used to describe
-      the method used to diagnose the patient's comorbidity disease.
-    cases.follow_ups.created_datetime: A combination of date and time of day in the
-      form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.follow_ups.days_to_adverse_event: Number of days between the date used for
-      index and the date of the patient's adverse event.
-    cases.follow_ups.days_to_comorbidity: Number of days between the date used for
-      index and the date the patient was diagnosed with a comorbidity.
-    cases.follow_ups.days_to_follow_up: Number of days between the date used for index
-      and the date of the patient's last follow-up appointment or contact.
-    cases.follow_ups.days_to_progression: Number of days between the date used for
-      index and the date the patient's disease progressed.
-    cases.follow_ups.days_to_progression_free: Number of days between the date used
-      for index and the date the patient's disease was formally confirmed as progression-free.
-    cases.follow_ups.days_to_recurrence: Number of days between the date used for
-      index and the date the patient's disease recurred.
-    cases.follow_ups.diabetes_treatment_type: Text term used to describe the types
-      of treatment used to manage diabetes.
-    cases.follow_ups.disease_response: Code assigned to describe the patient's response
-      or outcome to the disease.
-    cases.follow_ups.dlco_ref_predictive_percent: The value, as a percentage of predicted
-      lung volume, measuring the amount of carbon monoxide detected in a patient's
-      lungs.
-    cases.follow_ups.ecog_performance_status: The ECOG functional performance status
-      of the patient/participant.
-    cases.follow_ups.fev1_fvc_post_bronch_percent: Percentage value to represent result
-      of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity
-      (FVC) post-bronchodilator.
-    cases.follow_ups.fev1_fvc_pre_bronch_percent: Percentage value to represent result
-      of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity
-      (FVC) pre-bronchodilator.
-    cases.follow_ups.fev1_ref_post_bronch_percent: The percentage comparison to a
-      normal value reference range of the volume of air that a patient can forcibly
-      exhale from the lungs in one second post-bronchodilator.
-    cases.follow_ups.fev1_ref_pre_bronch_percent: The percentage comparison to a normal
-      value reference range of the volume of air that a patient can forcibly exhale
-      from the lungs in one second pre-bronchodilator.
-    cases.follow_ups.height: The height of the patient in centimeters.
-    cases.follow_ups.hepatitis_sustained_virological_response: The yes/no/unknown
-      indicator used to describe whether the patient received treatment for a risk
-      factor the patient had at the time of or prior to their diagnosis.
-    cases.follow_ups.hpv_positive_type: Text classification to represent the strain
-      or type of human papillomavirus identified in an individual.
-    cases.follow_ups.karnofsky_performance_status: Text term used to describe the
-      classification used of the functional capabilities of a person.
-    cases.follow_ups.menopause_status: Text term used to describe the patient's menopause
-      status.
-    cases.follow_ups.molecular_tests.aa_change: 'Alphanumeric value used to describe
-      the amino acid change for a specific genetic variant. Example: R116Q.'
-    cases.follow_ups.molecular_tests.antigen: The text term used to describe an antigen
-      included in molecular testing.
-    cases.follow_ups.molecular_tests.batch_id: GDC submission batch indicator. It
-      is unique within the context of a project.
-    cases.follow_ups.molecular_tests.biospecimen_type: The text term used to describe
-      the biological material used for testing, diagnostic, treatment or research
-      purposes.
-    cases.follow_ups.molecular_tests.blood_test_normal_range_lower: Numeric value
-      used to describe the lower limit of the normal range used to describe a healthy
-      individual at the institution where the test was completed.
-    cases.follow_ups.molecular_tests.blood_test_normal_range_upper: Numeric value
-      used to describe the upper limit of the normal range used to describe a healthy
-      individual at the institution where the test was completed.
-    cases.follow_ups.molecular_tests.cell_count: Numeric value used to describe the
-      number of cells used for molecular testing.
-    cases.follow_ups.molecular_tests.chromosome: The text term used to describe a
-      chromosome targeted or included in molecular testing. If a specific genetic
-      variant is being reported, this property can be used to capture the chromosome
-      where that variant is located.
-    cases.follow_ups.molecular_tests.copy_number: Numeric value used to describe the
-      number of times a section of the genome is repeated or copied within an insertion,
-      duplication or deletion variant.
-    cases.follow_ups.molecular_tests.created_datetime: A combination of date and time
-      of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.follow_ups.molecular_tests.cytoband: 'Alphanumeric value used to describe
-      the cytoband or chromosomal location targeted or included in molecular analysis.
-      If a specific genetic variant is being reported, this property can be used to
-      capture the cytoband where the variant is located. Format: [chromosome][chromosome
-      arm].[band+sub-bands]. Example: 17p13.1.'
-    cases.follow_ups.molecular_tests.exon: Exon number targeted or included in a molecular
-      analysis. If a specific genetic variant is being reported, this property can
-      be used to capture the exon where that variant is located.
-    cases.follow_ups.molecular_tests.gene_symbol: The text term used to describe a
-      gene targeted or included in molecular analysis. For rearrangements, this is
-      shold be used to represent the reference gene.
-    cases.follow_ups.molecular_tests.histone_family: The text term used to describe
-      the family, or classification of a group of basic proteins found in chromatin,
-      called histones.
-    cases.follow_ups.molecular_tests.histone_variant: The text term used to describe
-      a specific histone variants, which are proteins that substitute for the core
-      canonical histones.
-    cases.follow_ups.molecular_tests.intron: Intron number targeted or included in
-      molecular analysis. If a specific genetic variant is being reported, this property
-      can be used to capture the intron where that variant is located.
-    cases.follow_ups.molecular_tests.laboratory_test: The text term used to describe
-      the medical testing used to diagnose, treat or further understand a patient's
-      disease.
-    cases.follow_ups.molecular_tests.loci_abnormal_count: Numeric value used to describe
-      the number of loci determined to be abnormal.
-    cases.follow_ups.molecular_tests.loci_count: Numeric value used to describe the
-      number of loci tested.
-    cases.follow_ups.molecular_tests.locus: 'Alphanumeric value used to describe the
-      locus of a specific genetic variant. Example: NM_001126114.'
-    cases.follow_ups.molecular_tests.mismatch_repair_mutation: The yes/no/unknown
-      indicator used to describe whether the mutation included in molecular testing
-      was known to have an affect on the mismatch repair process.
-    cases.follow_ups.molecular_tests.molecular_analysis_method: The text term used
-      to describe the method used for molecular analysis.
-    cases.follow_ups.molecular_tests.molecular_consequence: The text term used to
-      describe the molecular consequence of genetic variation.
-    cases.follow_ups.molecular_tests.pathogenicity: The text used to describe a variant's
-      level of involvement in the cause of the patient's disease according to the
-      standards outlined by the American College of Medical Genetics and Genomics
-      (ACMG).
-    cases.follow_ups.molecular_tests.ploidy: Text term used to describe the number
-      of sets of homologous chromosomes.
-    cases.follow_ups.molecular_tests.project_id: Unique ID for any specific defined
-      piece of work that is undertaken or attempted to meet a single requirement.
-    cases.follow_ups.molecular_tests.second_exon: The second exon number involved
-      in molecular variation. If a specific genetic variant is being reported, this
-      property can be used to capture the second exon where that variant is located.
-      This property is typically used for a translocation where two different locations
-      are involved in the variation.
-    cases.follow_ups.molecular_tests.second_gene_symbol: The text term used to describe
-      a secondary gene targeted or included in molecular analysis. For rearrangements,
-      this is should represent the location of the variant.
-    cases.follow_ups.molecular_tests.specialized_molecular_test: Text term used to
-      describe a specific test that is not covered in the list of molecular analysis
-      methods.
-    cases.follow_ups.molecular_tests.state: The current state of the object.
-    cases.follow_ups.molecular_tests.submitter_id: A project-specific identifier for
-      a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
-    cases.follow_ups.molecular_tests.test_analyte_type: The text term used to describe
-      the type of analyte used for molecular testing.
-    cases.follow_ups.molecular_tests.test_result: The text term used to describe the
-      result of the molecular test. If the test result was a numeric value see test_value.
-    cases.follow_ups.molecular_tests.test_units: The text term used to describe the
-      units of the test value for a molecular test. This property is used in conjunction
-      with test_value.
-    cases.follow_ups.molecular_tests.test_value: The text term or numeric value used
-      to describe a sepcific result of a molecular test.
-    cases.follow_ups.molecular_tests.transcript: Alphanumeric value used to describe
-      the transcript of a specific genetic variant.
-    cases.follow_ups.molecular_tests.updated_datetime: A combination of date and time
-      of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.follow_ups.molecular_tests.variant_origin: The text term used to describe
-      the biological origin of a specific genetic variant.
-    cases.follow_ups.molecular_tests.variant_type: The text term used to describe
-      the type of genetic variation.
-    cases.follow_ups.molecular_tests.zygosity: The text term used to describe the
-      zygosity of a specific genetic variant.
-    cases.follow_ups.pancreatitis_onset_year: Numeric value to represent the year
-      that the patient was diagnosed with clinical chronic pancreatitis.
-    cases.follow_ups.progression_or_recurrence: Yes/No/Unknown indicator to identify
-      whether a patient has had a new tumor event after initial treatment.
-    cases.follow_ups.progression_or_recurrence_anatomic_site: The text term used to
-      describe the anatomic site of the progressive or recurrent disease.
-    cases.follow_ups.progression_or_recurrence_type: The text term used to describe
-      the type of progressive or recurrent disease or relapsed disease.
-    cases.follow_ups.project_id: Unique ID for any specific defined piece of work
-      that is undertaken or attempted to meet a single requirement.
-    cases.follow_ups.reflux_treatment_type: Text term used to describe the types of
-      treatment used to manage gastroesophageal reflux disease (GERD).
-    cases.follow_ups.risk_factor: The text term used to describe a risk factor the
-      patient had at the time of or prior to their diagnosis.
-    cases.follow_ups.risk_factor_treatment: The yes/no/unknown indicator used to describe
-      whether the patient received treatment for a risk factor the patient had at
-      the time of or prior to their diagnosis.
-    cases.follow_ups.state: The current state of the object.
-    cases.follow_ups.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
-    cases.follow_ups.updated_datetime: A combination of date and time of day in the
-      form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.follow_ups.viral_hepatitis_serologies: Text term that describes the kind
-      of serological laboratory test used to determine the patient's hepatitus status.
-    cases.follow_ups.weight: The weight of the patient measured in kilograms.
-    cases.project.awg_review: Indicates that the project is an AWG project.
     cases.project.code: Project code
     cases.project.dbgap_accession_number: The dbgap accession number for the project.
     cases.project.disease_type: Full name for the project
-    cases.project.in_review: Indicates that the project is under review by the submitter.
-      Upload and data modification is disabled.
     cases.project.intended_release_date: Tracks a Project's intended release date.
-    cases.project.is_legacy: Indicates whether a project will appear in the Legacy
-      Archive.
     cases.project.name: Display name for the project
     cases.project.primary_site: Primary site for the project
     cases.project.program.dbgap_accession_number: The dbgap accession number provided
@@ -1091,15 +575,14 @@ _meta:
     cases.project.program.name: Full name/title of the program.
     cases.project.releasable: A project can only be released by the user when `releasable`
       is true.
-    cases.project.release_requested: User requests that the GDC release the project.
-      Release can only be requested if the project is releasable.
-    cases.project.released: To release a project is to tell the GDC to include all
-      submitted entities in the next GDC index.
-    cases.project.request_submission: Indicates that the user has requested submission
-      to the GDC for harmonization.
-    cases.project.state: The possible states a project can be in.  All but `open`
-      are equivalent to some type of locked state.
-    cases.project.submission_enabled: Indicates if submission to a project is allowed.
+    cases.project.released: 'To release a project is to tell the GDC to include all
+      submitted
+
+      entities in the next GDC index.'
+    cases.project.state: 'The possible states a project can be in.  All but `open`
+      are
+
+      equivalent to some type of locked state.'
     cases.samples.aliquots.aliquot_quantity: The quantity in micrograms (ug) of the
       aliquot(s) derived from the analyte(s) shipped for sequencing and characterization.
     cases.samples.aliquots.aliquot_volume: The volume in microliters (ml) of the aliquot(s)
@@ -1109,86 +592,19 @@ _meta:
       specimen analyte.
     cases.samples.aliquots.analyte_type_id: A single letter code used to identify
       a type of molecular analyte.
-    cases.samples.aliquots.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
     cases.samples.aliquots.concentration: Numeric value that represents the concentration
       of an analyte or aliquot extracted from the sample or sample portion, measured
       in milligrams per milliliter.
     cases.samples.aliquots.created_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.aliquots.no_matched_normal_low_pass_wgs: There will be no matched
-      normal low pass WGS aliquots for this case that can be used for variant calling
-      purposes. The GDC may elect to use a single tumor calling pipeline to process
-      this data.
-    cases.samples.aliquots.no_matched_normal_targeted_sequencing: There will be no
-      matched normal Targeted Sequencing aliquots for this case that can be used for
-      variant calling purposes. The GDC may elect to use a single tumor calling pipeline
-      to process this data.
-    cases.samples.aliquots.no_matched_normal_wgs: There will be no matched normal
-      WGS aliquots for this case that can be used for variant calling purposes. The
-      GDC may elect to use a single tumor calling pipeline to process this data.
-    cases.samples.aliquots.no_matched_normal_wxs: There will be no matched normal
-      WXS aliquots for this case that can be used for variant calling purposes. The
-      GDC may elect to use a single tumor calling pipeline to process this data.
     cases.samples.aliquots.project_id: Unique ID for any specific defined piece of
       work that is undertaken or attempted to meet a single requirement.
-    cases.samples.aliquots.selected_normal_low_pass_wgs: Denotes which low-pass WGS
-      normal aliquot the submitter prefers to use for variant calling. Only one normal
-      per experimental strategy per case can be selected.
-    cases.samples.aliquots.selected_normal_targeted_sequencing: Denotes which targeted_sequencing
-      normal aliquot the submitter prefers to use for variant calling. Only one normal
-      per experimental strategy per case can be selected.
-    cases.samples.aliquots.selected_normal_wgs: Denotes which WGS normal aliquot the
-      submitter prefers to use for variant calling. Only one normal per experimental
-      strategy per case can be selected.
-    cases.samples.aliquots.selected_normal_wxs: Denotes which WXS normal aliquot the
-      submitter prefers to use for variant calling. Only one normal per experimental
-      strategy per case can be selected.
     cases.samples.aliquots.source_center: Name of the center that provided the item.
     cases.samples.aliquots.state: The current state of the object.
-    cases.samples.aliquots.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.aliquots.submitter_id: The legacy barcode used before prior to the
+      use UUIDs. For TCGA this is bcraliquotbarcode.
     cases.samples.aliquots.updated_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.analytes.a260_a280_ratio: Numeric value that represents the sample
-      ratio of nucleic acid absorbance at 260 nm and 280 nm, used to determine a measure
-      of DNA purity.
-    cases.samples.analytes.amount: Weight in grams or volume in mL.
-    cases.samples.analytes.analyte_quantity: The quantity in micrograms (ug) of the
-      analyte(s) derived from the analyte(s) shipped for sequencing and characterization.
-    cases.samples.analytes.analyte_type: Text term that represents the kind of molecular
-      specimen analyte.
-    cases.samples.analytes.analyte_type_id: A single letter code used to identify
-      a type of molecular analyte.
-    cases.samples.analytes.analyte_volume: The volume in microliters (ul) of the aliquot(s)
-      derived from the analyte(s) shipped for sequencing and characterization.
-    cases.samples.analytes.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
-    cases.samples.analytes.concentration: Numeric value that represents the concentration
-      of an analyte or aliquot extracted from the sample or sample portion, measured
-      in milligrams per milliliter.
-    cases.samples.analytes.created_datetime: A combination of date and time of day
-      in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.analytes.normal_tumor_genotype_snp_match: Text term that represents
-      whether or not the genotype of the normal tumor matches or if the data is not
-      available.
-    cases.samples.analytes.project_id: Unique ID for any specific defined piece of
-      work that is undertaken or attempted to meet a single requirement.
-    cases.samples.analytes.ribosomal_rna_28s_16s_ratio: The 28S/18S ribosomal RNA
-      band ratio used to assess the quality of total RNA.
-    cases.samples.analytes.spectrophotometer_method: Name of the method used to determine
-      the concentration of purified nucleic acid within a solution.
-    cases.samples.analytes.state: The current state of the object.
-    cases.samples.analytes.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
-    cases.samples.analytes.updated_datetime: A combination of date and time of day
-      in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.analytes.well_number: Numeric value that represents the the well
-      location within a plate for the analyte or aliquot from the sample.
-    cases.samples.annotations.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
     cases.samples.annotations.category: Top level characterization of the annotation.
     cases.samples.annotations.classification: Top level classification of the annotation.
     cases.samples.annotations.created_datetime: A combination of date and time of
@@ -1205,18 +621,11 @@ _meta:
       of work that is undertaken or attempted to meet a single requirement.
     cases.samples.annotations.state: The current state of the object.
     cases.samples.annotations.status: Status of the annotation.
-    cases.samples.annotations.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.annotations.submitter_id: null
     cases.samples.annotations.updated_datetime: A combination of date and time of
       day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.batch_id: GDC submission batch indicator. It is unique within the
-      context of a project.
     cases.samples.biospecimen_anatomic_site: Text term that represents the name of
       the primary disease site of the submitted tumor sample.
-    cases.samples.biospecimen_laterality: For tumors in paired organs, designates
-      the side on which the specimen was obtained.
-    cases.samples.catalog_reference: HCMI catalog reference number for cancer model.
     cases.samples.composition: Text term that represents the cellular composition
       of the sample.
     cases.samples.created_datetime: A combination of date and time of day in the form
@@ -1228,18 +637,9 @@ _meta:
       of days.
     cases.samples.days_to_sample_procurement: The number of days from the date the
       patient was diagnosed to the date of the procedure that produced the sample.
-    cases.samples.diagnosis_pathologically_confirmed: The histologic description of
-      tissue or cells confirmed by a pathology review of frozen or formalin fixed
-      slide(s) completed after the diagnostic pathology review of the tumor sample
-      used to extract analyte(s).
-    cases.samples.distance_normal_to_tumor: Text term to signify the distance between
-      the tumor tissue and the normal control tissue that was procured for matching
-      normal DNA.
-    cases.samples.distributor_reference: Distributor reference number for cancer model.
+    cases.samples.diagnosis_pathologically_confirmed: null
     cases.samples.freezing_method: Text term that represents the method used for freezing
       the sample.
-    cases.samples.growth_rate: Rate at which the model grows, measured as hours to
-      time to split.
     cases.samples.initial_weight: Numeric value that represents the initial weight
       of the sample, measured in milligrams.
     cases.samples.intermediate_dimension: null
@@ -1250,8 +650,6 @@ _meta:
       used to extract analyte(s).
     cases.samples.oct_embedded: Indicator of whether or not the sample was embedded
       in Optimal Cutting Temperature (OCT) compound.
-    cases.samples.passage_count: Number of passages (splits) between the original
-      tissue and this model.
     cases.samples.pathology_report_uuid: UUID of the related pathology report.
     cases.samples.portions.analytes.a260_a280_ratio: Numeric value that represents
       the sample ratio of nucleic acid absorbance at 260 nm and 280 nm, used to determine
@@ -1268,8 +666,6 @@ _meta:
       the kind of molecular specimen analyte.
     cases.samples.portions.analytes.aliquots.analyte_type_id: A single letter code
       used to identify a type of molecular analyte.
-    cases.samples.portions.analytes.aliquots.annotations.batch_id: GDC submission
-      batch indicator. It is unique within the context of a project.
     cases.samples.portions.analytes.aliquots.annotations.category: Top level characterization
       of the annotation.
     cases.samples.portions.analytes.aliquots.annotations.classification: Top level
@@ -1290,14 +686,9 @@ _meta:
     cases.samples.portions.analytes.aliquots.annotations.state: The current state
       of the object.
     cases.samples.portions.analytes.aliquots.annotations.status: Status of the annotation.
-    cases.samples.portions.analytes.aliquots.annotations.submitter_id: A project-specific
-      identifier for a node. This property is the calling card/nickname/alias for
-      a unit of submission. It can be used in place of the UUID for identifying or
-      recalling a node.
+    cases.samples.portions.analytes.aliquots.annotations.submitter_id: null
     cases.samples.portions.analytes.aliquots.annotations.updated_datetime: A combination
       of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.portions.analytes.aliquots.batch_id: GDC submission batch indicator.
-      It is unique within the context of a project.
     cases.samples.portions.analytes.aliquots.center.center_type: Type classification
       of the center (e.g. CGCC).
     cases.samples.portions.analytes.aliquots.center.code: Numeric code for the center.
@@ -1312,42 +703,13 @@ _meta:
       portion, measured in milligrams per milliliter.
     cases.samples.portions.analytes.aliquots.created_datetime: A combination of date
       and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.portions.analytes.aliquots.no_matched_normal_low_pass_wgs: There
-      will be no matched normal low pass WGS aliquots for this case that can be used
-      for variant calling purposes. The GDC may elect to use a single tumor calling
-      pipeline to process this data.
-    cases.samples.portions.analytes.aliquots.no_matched_normal_targeted_sequencing: There
-      will be no matched normal Targeted Sequencing aliquots for this case that can
-      be used for variant calling purposes. The GDC may elect to use a single tumor
-      calling pipeline to process this data.
-    cases.samples.portions.analytes.aliquots.no_matched_normal_wgs: There will be
-      no matched normal WGS aliquots for this case that can be used for variant calling
-      purposes. The GDC may elect to use a single tumor calling pipeline to process
-      this data.
-    cases.samples.portions.analytes.aliquots.no_matched_normal_wxs: There will be
-      no matched normal WXS aliquots for this case that can be used for variant calling
-      purposes. The GDC may elect to use a single tumor calling pipeline to process
-      this data.
     cases.samples.portions.analytes.aliquots.project_id: Unique ID for any specific
       defined piece of work that is undertaken or attempted to meet a single requirement.
-    cases.samples.portions.analytes.aliquots.selected_normal_low_pass_wgs: Denotes
-      which low-pass WGS normal aliquot the submitter prefers to use for variant calling.
-      Only one normal per experimental strategy per case can be selected.
-    cases.samples.portions.analytes.aliquots.selected_normal_targeted_sequencing: Denotes
-      which targeted_sequencing normal aliquot the submitter prefers to use for variant
-      calling. Only one normal per experimental strategy per case can be selected.
-    cases.samples.portions.analytes.aliquots.selected_normal_wgs: Denotes which WGS
-      normal aliquot the submitter prefers to use for variant calling. Only one normal
-      per experimental strategy per case can be selected.
-    cases.samples.portions.analytes.aliquots.selected_normal_wxs: Denotes which WXS
-      normal aliquot the submitter prefers to use for variant calling. Only one normal
-      per experimental strategy per case can be selected.
     cases.samples.portions.analytes.aliquots.source_center: Name of the center that
       provided the item.
     cases.samples.portions.analytes.aliquots.state: The current state of the object.
-    cases.samples.portions.analytes.aliquots.submitter_id: A project-specific identifier
-      for a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.analytes.aliquots.submitter_id: The legacy barcode used
+      before prior to the use UUIDs. For TCGA this is bcraliquotbarcode.
     cases.samples.portions.analytes.aliquots.updated_datetime: A combination of date
       and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.portions.analytes.amount: Weight in grams or volume in mL.
@@ -1357,10 +719,8 @@ _meta:
       of molecular specimen analyte.
     cases.samples.portions.analytes.analyte_type_id: A single letter code used to
       identify a type of molecular analyte.
-    cases.samples.portions.analytes.analyte_volume: The volume in microliters (ul)
-      of the aliquot(s) derived from the analyte(s) shipped for sequencing and characterization.
-    cases.samples.portions.analytes.annotations.batch_id: GDC submission batch indicator.
-      It is unique within the context of a project.
+    cases.samples.portions.analytes.analyte_volume: The volume in microliters (ml)
+      of the analyte(s) derived from the analyte(s) shipped for sequencing and characterization.
     cases.samples.portions.analytes.annotations.category: Top level characterization
       of the annotation.
     cases.samples.portions.analytes.annotations.classification: Top level classification
@@ -1379,13 +739,9 @@ _meta:
       defined piece of work that is undertaken or attempted to meet a single requirement.
     cases.samples.portions.analytes.annotations.state: The current state of the object.
     cases.samples.portions.analytes.annotations.status: Status of the annotation.
-    cases.samples.portions.analytes.annotations.submitter_id: A project-specific identifier
-      for a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.analytes.annotations.submitter_id: null
     cases.samples.portions.analytes.annotations.updated_datetime: A combination of
       date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.portions.analytes.batch_id: GDC submission batch indicator. It is
-      unique within the context of a project.
     cases.samples.portions.analytes.concentration: Numeric value that represents the
       concentration of an analyte or aliquot extracted from the sample or sample portion,
       measured in milligrams per milliliter.
@@ -1401,15 +757,12 @@ _meta:
     cases.samples.portions.analytes.spectrophotometer_method: Name of the method used
       to determine the concentration of purified nucleic acid within a solution.
     cases.samples.portions.analytes.state: The current state of the object.
-    cases.samples.portions.analytes.submitter_id: A project-specific identifier for
-      a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.analytes.submitter_id: The legacy barcode used before prior
+      to the use UUIDs, varies by project. For TCGA this is bcranalytebarcode.
     cases.samples.portions.analytes.updated_datetime: A combination of date and time
       of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.portions.analytes.well_number: Numeric value that represents the
       the well location within a plate for the analyte or aliquot from the sample.
-    cases.samples.portions.annotations.batch_id: GDC submission batch indicator. It
-      is unique within the context of a project.
     cases.samples.portions.annotations.category: Top level characterization of the
       annotation.
     cases.samples.portions.annotations.classification: Top level classification of
@@ -1428,13 +781,9 @@ _meta:
       piece of work that is undertaken or attempted to meet a single requirement.
     cases.samples.portions.annotations.state: The current state of the object.
     cases.samples.portions.annotations.status: Status of the annotation.
-    cases.samples.portions.annotations.submitter_id: A project-specific identifier
-      for a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.annotations.submitter_id: null
     cases.samples.portions.annotations.updated_datetime: A combination of date and
       time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.portions.batch_id: GDC submission batch indicator. It is unique
-      within the context of a project.
     cases.samples.portions.center.center_type: Type classification of the center (e.g.
       CGCC).
     cases.samples.portions.center.code: Numeric code for the center.
@@ -1452,8 +801,6 @@ _meta:
       number assigned to a portion of the sample.
     cases.samples.portions.project_id: Unique ID for any specific defined piece of
       work that is undertaken or attempted to meet a single requirement.
-    cases.samples.portions.slides.annotations.batch_id: GDC submission batch indicator.
-      It is unique within the context of a project.
     cases.samples.portions.slides.annotations.category: Top level characterization
       of the annotation.
     cases.samples.portions.slides.annotations.classification: Top level classification
@@ -1472,13 +819,9 @@ _meta:
       defined piece of work that is undertaken or attempted to meet a single requirement.
     cases.samples.portions.slides.annotations.state: The current state of the object.
     cases.samples.portions.slides.annotations.status: Status of the annotation.
-    cases.samples.portions.slides.annotations.submitter_id: A project-specific identifier
-      for a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.slides.annotations.submitter_id: null
     cases.samples.portions.slides.annotations.updated_datetime: A combination of date
       and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.portions.slides.batch_id: GDC submission batch indicator. It is
-      unique within the context of a project.
     cases.samples.portions.slides.created_datetime: A combination of date and time
       of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.portions.slides.number_proliferating_cells: Numeric value that represents
@@ -1511,37 +854,32 @@ _meta:
       or specimen but are not malignant such as fibroblasts, vascular structures,
       etc.
     cases.samples.portions.slides.percent_tumor_cells: Numeric value that represents
-      the percentage of infiltration by tumor cells in a sample.
+      the percentage of infiltration by granulocytes in a sample.
     cases.samples.portions.slides.percent_tumor_nuclei: Numeric value to represent
       the percentage of tumor nuclei in a malignant neoplasm sample or specimen.
     cases.samples.portions.slides.project_id: Unique ID for any specific defined piece
       of work that is undertaken or attempted to meet a single requirement.
     cases.samples.portions.slides.section_location: Tissue source of the slide.
     cases.samples.portions.slides.state: The current state of the object.
-    cases.samples.portions.slides.submitter_id: A project-specific identifier for
-      a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.slides.submitter_id: The legacy barcode used before prior
+      to the use UUIDs, varies by project. For TCGA, this is bcrslidebarcode.
     cases.samples.portions.slides.updated_datetime: A combination of date and time
       of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.portions.state: The current state of the object.
-    cases.samples.portions.submitter_id: A project-specific identifier for a node.
-      This property is the calling card/nickname/alias for a unit of submission. It
-      can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.portions.submitter_id: The legacy barcode used before prior to the
+      use UUIDs, varies by project. For TCGA this is bcrportionbarcode.
     cases.samples.portions.updated_datetime: A combination of date and time of day
       in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.portions.weight: Numeric value that represents the sample portion
       weight, measured in milligrams.
     cases.samples.preservation_method: Text term that represents the method used to
       preserve the sample.
-    cases.samples.project_id: Unique ID for any specific defined piece of work that
-      is undertaken or attempted to meet a single requirement.
+    cases.samples.project_id: null
     cases.samples.sample_type: Text term to describe the source of a biospecimen used
       for a laboratory test.
     cases.samples.sample_type_id: The accompanying sample type id for the sample type.
     cases.samples.shortest_dimension: Numeric value that represents the shortest dimension
       of the sample, measured in millimeters.
-    cases.samples.slides.annotations.batch_id: GDC submission batch indicator. It
-      is unique within the context of a project.
     cases.samples.slides.annotations.category: Top level characterization of the annotation.
     cases.samples.slides.annotations.classification: Top level classification of the
       annotation.
@@ -1559,13 +897,9 @@ _meta:
       piece of work that is undertaken or attempted to meet a single requirement.
     cases.samples.slides.annotations.state: The current state of the object.
     cases.samples.slides.annotations.status: Status of the annotation.
-    cases.samples.slides.annotations.submitter_id: A project-specific identifier for
-      a node. This property is the calling card/nickname/alias for a unit of submission.
-      It can be used in place of the UUID for identifying or recalling a node.
+    cases.samples.slides.annotations.submitter_id: null
     cases.samples.slides.annotations.updated_datetime: A combination of date and time
       of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    cases.samples.slides.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     cases.samples.slides.created_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.slides.number_proliferating_cells: Numeric value that represents
@@ -1594,22 +928,20 @@ _meta:
       of reactive cells that are present in a malignant tumor sample or specimen but
       are not malignant such as fibroblasts, vascular structures, etc.
     cases.samples.slides.percent_tumor_cells: Numeric value that represents the percentage
-      of infiltration by tumor cells in a sample.
+      of infiltration by granulocytes in a sample.
     cases.samples.slides.percent_tumor_nuclei: Numeric value to represent the percentage
       of tumor nuclei in a malignant neoplasm sample or specimen.
     cases.samples.slides.project_id: Unique ID for any specific defined piece of work
       that is undertaken or attempted to meet a single requirement.
     cases.samples.slides.section_location: Tissue source of the slide.
     cases.samples.slides.state: The current state of the object.
-    cases.samples.slides.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    cases.samples.slides.submitter_id: The legacy barcode used before prior to the
+      use UUIDs, varies by project. For TCGA, this is bcrslidebarcode.
     cases.samples.slides.updated_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     cases.samples.state: The current state of the object.
-    cases.samples.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
+    cases.samples.submitter_id: The legacy barcode used before prior to the use UUIDs,
+      varies by project. For TCGA this is bcrsamplebarcode.
     cases.samples.time_between_clamping_and_freezing: Numeric representation of the
       elapsed time between the surgical clamping of blood supply and freezing of the
       sample, measured in minutes.
@@ -1627,8 +959,6 @@ _meta:
     cases.tissue_source_site.code: TCGA-provided TSS code.
     cases.tissue_source_site.name: Name of the source site.
     cases.tissue_source_site.project: Study name of the project.
-    files.annotations.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     files.annotations.category: Top level characterization of the annotation.
     files.annotations.classification: Top level classification of the annotation.
     files.annotations.created_datetime: A combination of date and time of day in the
@@ -1645,13 +975,9 @@ _meta:
       that is undertaken or attempted to meet a single requirement.
     files.annotations.state: The current state of the object.
     files.annotations.status: Status of the annotation.
-    files.annotations.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    files.annotations.submitter_id: null
     files.annotations.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    files.archive.batch_id: GDC submission batch indicator. It is unique within the
-      context of a project.
     files.archive.created_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     files.archive.data_category: Broad categorization of the contents of the data
@@ -1663,43 +989,31 @@ _meta:
     files.archive.file_size: The size of the data file (object) in bytes.
     files.archive.file_state: The current state of the data file object.
     files.archive.md5sum: The 128-bit hash value expressed as a 32 digit hexadecimal
-      number (in lower case) used as a file's digital fingerprint.
+      number used as a file's digital fingerprint.
     files.archive.project_id: Unique ID for any specific defined piece of work that
       is undertaken or attempted to meet a single requirement.
     files.archive.revision: The revision of this archive in the DCC.
     files.archive.state: The current state of the object.
     files.archive.state_comment: Optional comment about why the file is in the current
       state, mainly for invalid state.
-    files.archive.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
+    files.archive.submitter_id: The file ID assigned by the submitter.
     files.archive.updated_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    files.cases.batch_id: GDC submission batch indicator. It is unique within the
-      context of a project.
     files.cases.created_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     files.cases.days_to_lost_to_followup: The number of days between the date used
       for index and to the date the patient was lost to follow-up.
-    files.cases.disease_type: The text term used to describe the type of malignant
-      disease, as categorized by the World Health Organization's (WHO) International
-      Classification of Diseases for Oncology (ICD-O).
-    files.cases.index_date: The text term used to describe the reference or anchor
-      date used when for date obfuscation, where a single date is obscurred by creating
-      one or more date ranges in relation to this date.
-    files.cases.lost_to_followup: The yes/no/unknown indicator used to describe whether
-      a patient was unable to be contacted or seen for follow-up information.
-    files.cases.primary_site: The text term used to describe the primary site of disease,
-      as categorized by the World Health Organization's (WHO) International Classification
-      of Diseases for Oncology (ICD-O). This categorization groups cases into general
-      categories. Reference tissue_or_organ_of_origin on the diagnosis node for more
-      specific primary sites of disease.
+    files.cases.disease_type: Full name for the project.
+    files.cases.index_date: The reference or anchor date used during date obfuscation,
+      where a single date is obscurred by creating one or more date ranges in relation
+      to this date.
+    files.cases.lost_to_followup: A yes/no indicator related to whether a patient
+      was unable to be contacted for follow-up.
+    files.cases.primary_site: Primary site for the project.
     files.cases.project_id: Unique ID for any specific defined piece of work that
       is undertaken or attempted to meet a single requirement.
     files.cases.state: The current state of the object.
-    files.cases.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
+    files.cases.submitter_id: null
     files.cases.updated_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     files.center.center_type: Type classification of the center (e.g. CGCC).
@@ -1711,45 +1025,32 @@ _meta:
     files.data_type.data_category.name: name of this data type
     files.data_type.name: name of this data subtype
     files.experimental_strategy.name: name of this record
-    files.file.batch_id: GDC submission batch indicator. It is unique within the context
-      of a project.
     files.file.created_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     files.file.error_type: Type of error for the data file object.
-    files.file.file_name: The name (or part of a name) of a file (of any type).
-    files.file.file_size: The size of the data file (object) in bytes.
+    files.file.file_name: The file (object) name
+    files.file.file_size: The size file (object) in bytes
     files.file.file_state: The current state of the data file object.
-    files.file.md5sum: The 128-bit hash value expressed as a 32 digit hexadecimal
-      number (in lower case) used as a file's digital fingerprint.
-    files.file.project_id: Unique ID for any specific defined piece of work that is
-      undertaken or attempted to meet a single requirement.
+    files.file.md5sum: The MD5 hash of this file
+    files.file.project_id: null
     files.file.state: The current state of the object.
     files.file.state_comment: Optional comment about why the file is in the current
       state, mainly for invalid state.
-    files.file.submitter_id: A project-specific identifier for a node. This property
-      is the calling card/nickname/alias for a unit of submission. It can be used
-      in place of the UUID for identifying or recalling a node.
+    files.file.submitter_id: The file id assigned by the submitter
     files.file.updated_datetime: A combination of date and time of day in the form
       [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
-    files.metadata_files.batch_id: GDC submission batch indicator. It is unique within
-      the context of a project.
     files.metadata_files.created_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     files.metadata_files.error_type: Type of error for the data file object.
-    files.metadata_files.file_name: The name (or part of a name) of a file (of any
-      type).
-    files.metadata_files.file_size: The size of the data file (object) in bytes.
+    files.metadata_files.file_name: The file (object) name
+    files.metadata_files.file_size: The size file (object) in bytes
     files.metadata_files.file_state: The current state of the data file object.
-    files.metadata_files.md5sum: The 128-bit hash value expressed as a 32 digit hexadecimal
-      number (in lower case) used as a file's digital fingerprint.
-    files.metadata_files.project_id: Unique ID for any specific defined piece of work
-      that is undertaken or attempted to meet a single requirement.
+    files.metadata_files.md5sum: The MD5 hash of this file
+    files.metadata_files.project_id: null
     files.metadata_files.state: The current state of the object.
     files.metadata_files.state_comment: Optional comment about why the file is in
       the current state, mainly for invalid state.
-    files.metadata_files.submitter_id: A project-specific identifier for a node. This
-      property is the calling card/nickname/alias for a unit of submission. It can
-      be used in place of the UUID for identifying or recalling a node.
+    files.metadata_files.submitter_id: The file id assigned by the submitter
     files.metadata_files.updated_datetime: A combination of date and time of day in
       the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
     files.platform.name: name of this platform
@@ -1757,25 +1058,19 @@ _meta:
     projects.program.dbgap_accession_number: The dbgap accession number provided for
       the program.
     projects.program.name: Full name/title of the program.
-    projects.project.awg_review: Indicates that the project is an AWG project.
     projects.project.code: Project code
     projects.project.dbgap_accession_number: The dbgap accession number for the project.
     projects.project.disease_type: Full name for the project
-    projects.project.in_review: Indicates that the project is under review by the
-      submitter. Upload and data modification is disabled.
     projects.project.intended_release_date: Tracks a Project's intended release date.
-    projects.project.is_legacy: Indicates whether a project will appear in the Legacy
-      Archive.
     projects.project.name: Display name for the project
     projects.project.primary_site: Primary site for the project
     projects.project.releasable: A project can only be released by the user when `releasable`
       is true.
-    projects.project.release_requested: User requests that the GDC release the project.
-      Release can only be requested if the project is releasable.
-    projects.project.released: To release a project is to tell the GDC to include
-      all submitted entities in the next GDC index.
-    projects.project.request_submission: Indicates that the user has requested submission
-      to the GDC for harmonization.
-    projects.project.state: The possible states a project can be in.  All but `open`
-      are equivalent to some type of locked state.
-    projects.project.submission_enabled: Indicates if submission to a project is allowed.
+    projects.project.released: 'To release a project is to tell the GDC to include
+      all submitted
+
+      entities in the next GDC index.'
+    projects.project.state: 'The possible states a project can be in.  All but `open`
+      are
+
+      equivalent to some type of locked state.'

--- a/es-models/gdc_legacy_graph/file.mapping.yaml
+++ b/es-models/gdc_legacy_graph/file.mapping.yaml
@@ -58,6 +58,8 @@ properties:
         type: keyword
       file_size:
         type: long
+      file_state:
+        type: keyword
       md5sum:
         type: keyword
       revision:
@@ -134,8 +136,6 @@ properties:
         type: long
       demographic:
         properties:
-          age_at_index:
-            type: long
           cause_of_death:
             type: keyword
           created_datetime:
@@ -150,8 +150,6 @@ properties:
             type: keyword
           gender:
             type: keyword
-          premature_at_birth:
-            type: keyword
           race:
             type: keyword
           state:
@@ -162,8 +160,6 @@ properties:
             type: keyword
           vital_status:
             type: keyword
-          weeks_gestation_at_birth:
-            type: long
           year_of_birth:
             type: long
           year_of_death:
@@ -188,12 +184,6 @@ properties:
             type: keyword
           ajcc_pathologic_t:
             type: keyword
-          ajcc_staging_system_edition:
-            type: keyword
-          anaplasia_present:
-            type: keyword
-          anaplasia_present_type:
-            type: keyword
           ann_arbor_b_symptoms:
             type: keyword
           ann_arbor_clinical_stage:
@@ -202,116 +192,47 @@ properties:
             type: keyword
           ann_arbor_pathologic_stage:
             type: keyword
-          annotations:
-            properties:
-              annotation_id:
-                type: keyword
-              case_id:
-                type: keyword
-              case_submitter_id:
-                type: keyword
-              category:
-                type: keyword
-              classification:
-                type: keyword
-              created_datetime:
-                type: keyword
-              creator:
-                type: keyword
-              entity_id:
-                type: keyword
-              entity_submitter_id:
-                type: keyword
-              entity_type:
-                type: keyword
-              legacy_created_datetime:
-                type: keyword
-              legacy_updated_datetime:
-                type: keyword
-              notes:
-                type: keyword
-              state:
-                type: keyword
-              status:
-                type: keyword
-              submitter_id:
-                type: keyword
-              updated_datetime:
-                type: keyword
-            type: nested
           best_overall_response:
             type: keyword
           burkitt_lymphoma_clinical_variant:
             type: keyword
-          child_pugh_classification:
+          cause_of_death:
             type: keyword
           circumferential_resection_margin:
             type: long
           classification_of_tumor:
             type: keyword
-          cog_liver_stage:
-            type: keyword
-          cog_neuroblastoma_risk_group:
-            type: keyword
-          cog_renal_stage:
-            type: keyword
-          cog_rhabdomyosarcoma_risk_group:
+          colon_polyps_history:
             type: keyword
           created_datetime:
             type: keyword
           days_to_best_overall_response:
             type: long
+          days_to_birth:
+            type: long
+          days_to_death:
+            type: long
           days_to_diagnosis:
+            type: long
+          days_to_hiv_diagnosis:
             type: long
           days_to_last_follow_up:
             type: long
           days_to_last_known_disease_status:
             type: long
+          days_to_new_event:
+            type: long
           days_to_recurrence:
             type: long
           diagnosis_id:
             type: keyword
-          enneking_msts_grade:
-            type: keyword
-          enneking_msts_metastasis:
-            type: keyword
-          enneking_msts_stage:
-            type: keyword
-          enneking_msts_tumor_site:
-            type: keyword
-          esophageal_columnar_dysplasia_degree:
-            type: keyword
-          esophageal_columnar_metaplasia_present:
-            type: keyword
           figo_stage:
             type: keyword
-          first_symptom_prior_to_diagnosis:
+          hiv_positive:
             type: keyword
-          gastric_esophageal_junction_involvement:
+          hpv_positive_type:
             type: keyword
-          gleason_grade_group:
-            type: keyword
-          goblet_cells_columnar_mucosa_present:
-            type: keyword
-          gross_tumor_weight:
-            type: long
-          icd_10_code:
-            type: keyword
-          igcccg_stage:
-            type: keyword
-          inpc_grade:
-            type: keyword
-          inpc_histologic_group:
-            type: keyword
-          inrg_stage:
-            type: keyword
-          inss_stage:
-            type: keyword
-          irs_group:
-            type: keyword
-          irs_stage:
-            type: keyword
-          ishak_fibrosis_score:
+          hpv_status:
             type: keyword
           iss_stage:
             type: keyword
@@ -319,47 +240,39 @@ properties:
             type: keyword
           laterality:
             type: keyword
-          lymph_nodes_positive:
+          ldh_level_at_diagnosis:
             type: long
-          lymph_nodes_tested:
+          ldh_normal_range_upper:
+            type: long
+          lymph_nodes_positive:
             type: long
           lymphatic_invasion_present:
             type: keyword
-          masaoka_stage:
-            type: keyword
-          medulloblastoma_molecular_classification:
-            type: keyword
-          metastasis_at_diagnosis:
-            type: keyword
-          metastasis_at_diagnosis_site:
-            type: keyword
           method_of_diagnosis:
-            type: keyword
-          micropapillary_features:
-            type: keyword
-          mitosis_karyorrhexis_index:
             type: keyword
           morphology:
             type: keyword
+          new_event_anatomic_site:
+            type: keyword
+          new_event_type:
+            type: keyword
+          overall_survival:
+            type: long
           perineural_invasion_present:
             type: keyword
-          peripancreatic_lymph_nodes_positive:
-            type: keyword
-          peripancreatic_lymph_nodes_tested:
-            type: long
           primary_diagnosis:
-            type: keyword
-          primary_gleason_grade:
             type: keyword
           prior_malignancy:
             type: keyword
           prior_treatment:
             type: keyword
+          progression_free_survival:
+            type: long
+          progression_free_survival_event:
+            type: keyword
           progression_or_recurrence:
             type: keyword
           residual_disease:
-            type: keyword
-          secondary_gleason_grade:
             type: keyword
           site_of_resection_or_biopsy:
             type: keyword
@@ -367,22 +280,18 @@ properties:
             type: keyword
           submitter_id:
             type: keyword
-          supratentorial_localization:
-            type: keyword
-          synchronous_malignancy:
-            type: keyword
           tissue_or_organ_of_origin:
             type: keyword
           treatments:
             properties:
               created_datetime:
                 type: keyword
+              days_to_treatment:
+                type: long
               days_to_treatment_end:
                 type: long
               days_to_treatment_start:
                 type: long
-              initial_disease_status:
-                type: keyword
               regimen_or_line_of_therapy:
                 type: keyword
               state:
@@ -392,8 +301,6 @@ properties:
               therapeutic_agents:
                 type: keyword
               treatment_anatomic_site:
-                type: keyword
-              treatment_effect:
                 type: keyword
               treatment_id:
                 type: keyword
@@ -408,15 +315,7 @@ properties:
               updated_datetime:
                 type: keyword
             type: nested
-          tumor_confined_to_organ_of_origin:
-            type: keyword
-          tumor_focality:
-            type: keyword
           tumor_grade:
-            type: keyword
-          tumor_largest_dimension_diameter:
-            type: long
-          tumor_regression_grade:
             type: keyword
           tumor_stage:
             type: keyword
@@ -424,40 +323,24 @@ properties:
             type: keyword
           vascular_invasion_present:
             type: keyword
-          vascular_invasion_type:
-            type: keyword
-          weiss_assessment_score:
-            type: keyword
-          wilms_tumor_histologic_subtype:
+          vital_status:
             type: keyword
           year_of_diagnosis:
             type: long
         type: nested
-      diagnosis_ids:
-        type: keyword
       disease_type:
         type: keyword
       exposures:
         properties:
-          alcohol_days_per_week:
-            type: long
-          alcohol_drinks_per_day:
-            type: long
           alcohol_history:
             type: keyword
           alcohol_intensity:
-            type: keyword
-          asbestos_exposure:
             type: keyword
           bmi:
             type: long
           cigarettes_per_day:
             type: float
-          coal_dust_exposure:
-            type: keyword
           created_datetime:
-            type: keyword
-          environmental_tobacco_smoke_exposure:
             type: keyword
           exposure_id:
             type: keyword
@@ -465,27 +348,15 @@ properties:
             type: long
           pack_years_smoked:
             type: long
-          radon_exposure:
-            type: keyword
-          respirable_crystalline_silica_exposure:
-            type: keyword
-          smoking_frequency:
-            type: keyword
           state:
             type: keyword
           submitter_id:
-            type: keyword
-          time_between_waking_and_first_smoke:
             type: keyword
           tobacco_smoking_onset_year:
             type: long
           tobacco_smoking_quit_year:
             type: long
           tobacco_smoking_status:
-            type: keyword
-          type_of_smoke_exposure:
-            type: keyword
-          type_of_tobacco_used:
             type: keyword
           updated_datetime:
             type: keyword
@@ -516,166 +387,6 @@ properties:
             type: keyword
           updated_datetime:
             type: keyword
-        type: nested
-      follow_ups:
-        properties:
-          adverse_event:
-            type: keyword
-          barretts_esophagus_goblet_cells_present:
-            type: keyword
-          bmi:
-            type: long
-          cause_of_response:
-            type: keyword
-          comorbidity:
-            type: keyword
-          comorbidity_method_of_diagnosis:
-            type: keyword
-          created_datetime:
-            type: keyword
-          days_to_adverse_event:
-            type: long
-          days_to_comorbidity:
-            type: long
-          days_to_follow_up:
-            type: long
-          days_to_progression:
-            type: long
-          days_to_progression_free:
-            type: long
-          days_to_recurrence:
-            type: long
-          diabetes_treatment_type:
-            type: keyword
-          disease_response:
-            type: keyword
-          dlco_ref_predictive_percent:
-            type: long
-          ecog_performance_status:
-            type: keyword
-          fev1_fvc_post_bronch_percent:
-            type: long
-          fev1_fvc_pre_bronch_percent:
-            type: long
-          fev1_ref_post_bronch_percent:
-            type: long
-          fev1_ref_pre_bronch_percent:
-            type: long
-          follow_up_id:
-            type: keyword
-          height:
-            type: long
-          hepatitis_sustained_virological_response:
-            type: keyword
-          hpv_positive_type:
-            type: keyword
-          karnofsky_performance_status:
-            type: keyword
-          menopause_status:
-            type: keyword
-          molecular_tests:
-            properties:
-              aa_change:
-                type: keyword
-              antigen:
-                type: keyword
-              biospecimen_type:
-                type: keyword
-              blood_test_normal_range_lower:
-                type: long
-              blood_test_normal_range_upper:
-                type: long
-              cell_count:
-                type: long
-              chromosome:
-                type: keyword
-              copy_number:
-                type: long
-              created_datetime:
-                type: keyword
-              cytoband:
-                type: keyword
-              exon:
-                type: keyword
-              gene_symbol:
-                type: keyword
-              histone_family:
-                type: keyword
-              histone_variant:
-                type: keyword
-              intron:
-                type: keyword
-              laboratory_test:
-                type: keyword
-              loci_abnormal_count:
-                type: long
-              loci_count:
-                type: long
-              locus:
-                type: keyword
-              mismatch_repair_mutation:
-                type: keyword
-              molecular_analysis_method:
-                type: keyword
-              molecular_consequence:
-                type: keyword
-              molecular_test_id:
-                type: keyword
-              ploidy:
-                type: keyword
-              second_exon:
-                type: keyword
-              second_gene_symbol:
-                type: keyword
-              specialized_molecular_test:
-                type: keyword
-              state:
-                type: keyword
-              submitter_id:
-                type: keyword
-              test_analyte_type:
-                type: keyword
-              test_result:
-                type: keyword
-              test_units:
-                type: keyword
-              test_value:
-                type: long
-              transcript:
-                type: keyword
-              updated_datetime:
-                type: keyword
-              variant_origin:
-                type: keyword
-              variant_type:
-                type: keyword
-              zygosity:
-                type: keyword
-            type: nested
-          pancreatitis_onset_year:
-            type: long
-          progression_or_recurrence:
-            type: keyword
-          progression_or_recurrence_anatomic_site:
-            type: keyword
-          progression_or_recurrence_type:
-            type: keyword
-          reflux_treatment_type:
-            type: keyword
-          risk_factor:
-            type: keyword
-          risk_factor_treatment:
-            type: keyword
-          state:
-            type: keyword
-          submitter_id:
-            type: keyword
-          updated_datetime:
-            type: keyword
-          viral_hepatitis_serologies:
-            type: keyword
-          weight:
-            type: long
         type: nested
       index_date:
         type: keyword
@@ -756,10 +467,6 @@ properties:
             type: nested
           biospecimen_anatomic_site:
             type: keyword
-          biospecimen_laterality:
-            type: keyword
-          catalog_reference:
-            type: keyword
           composition:
             type: keyword
           created_datetime:
@@ -772,28 +479,20 @@ properties:
             type: long
           diagnosis_pathologically_confirmed:
             type: keyword
-          distance_normal_to_tumor:
-            type: keyword
-          distributor_reference:
-            type: keyword
           freezing_method:
             type: keyword
-          growth_rate:
-            type: long
           initial_weight:
             type: long
           intermediate_dimension:
-            type: long
+            type: keyword
           is_ffpe:
             type: keyword
           longest_dimension:
-            type: long
+            type: keyword
           method_of_sample_procurement:
             type: keyword
           oct_embedded:
             type: keyword
-          passage_count:
-            type: long
           pathology_report_uuid:
             type: keyword
           portions:
@@ -870,22 +569,6 @@ properties:
                       concentration:
                         type: long
                       created_datetime:
-                        type: keyword
-                      no_matched_normal_low_pass_wgs:
-                        type: keyword
-                      no_matched_normal_targeted_sequencing:
-                        type: keyword
-                      no_matched_normal_wgs:
-                        type: keyword
-                      no_matched_normal_wxs:
-                        type: keyword
-                      selected_normal_low_pass_wgs:
-                        type: keyword
-                      selected_normal_targeted_sequencing:
-                        type: keyword
-                      selected_normal_wgs:
-                        type: keyword
-                      selected_normal_wxs:
                         type: keyword
                       source_center:
                         type: keyword
@@ -1119,15 +802,15 @@ properties:
           sample_type_id:
             type: keyword
           shortest_dimension:
-            type: long
+            type: keyword
           state:
             type: keyword
           submitter_id:
             type: keyword
           time_between_clamping_and_freezing:
-            type: long
+            type: keyword
           time_between_excision_and_freezing:
-            type: long
+            type: keyword
           tissue_type:
             type: keyword
           tumor_code:
@@ -1146,8 +829,6 @@ properties:
       submitter_aliquot_ids:
         type: keyword
       submitter_analyte_ids:
-        type: keyword
-      submitter_diagnosis_ids:
         type: keyword
       submitter_id:
         type: keyword
@@ -1224,6 +905,8 @@ properties:
     type: keyword
   file_size:
     type: long
+  file_state:
+    type: keyword
   index_files:
     properties:
       created_datetime:
@@ -1238,6 +921,8 @@ properties:
         type: keyword
       file_size:
         type: long
+      file_state:
+        type: keyword
       md5sum:
         type: keyword
       state:
@@ -1271,6 +956,8 @@ properties:
         type: keyword
       file_size:
         type: long
+      file_state:
+        type: keyword
       md5sum:
         type: keyword
       state:


### PR DESCRIPTION
Context:
* There is no plan rebuilding legacy graph, but the mappings are out of date at this point, due to change in the dictionary
* We instead use the actual legacy graph mappings directly from Elasticsearch
* This should resolve various issues with missing data for the facets on the legacy archive portal