### PR TITLE
bring more diagnoses fields into viz indices

### DIFF
--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -92,6 +92,8 @@ properties:
         type: long
       classification_of_tumor:
         type: keyword
+      cog_renal_stage:
+        type: keyword
       colon_polyps_history:
         type: keyword
       days_to_diagnosis:
@@ -208,6 +210,8 @@ properties:
       tumor_stage:
         type: keyword
       vascular_invasion_present:
+        type: keyword
+      vascular_invasion_type:
         type: keyword
       year_of_diagnosis:
         type: long

--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -30,6 +30,8 @@ properties:
     type: long
   demographic:
     properties:
+      age_at_index:
+        type: long
       cause_of_death:
         type: keyword
       days_to_birth:
@@ -184,6 +186,10 @@ properties:
             type: long
           days_to_treatment_start:
             type: long
+          initial_disease_status:
+            type: keyword
+          regimen_or_line_of_therapy:
+            type: keyword
           state:
             type: keyword
           submitter_id:

--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -140,6 +140,8 @@ properties:
         type: keyword
       masaoka_stage:
         type: keyword
+      metastasis_at_diagnosis:
+        type: keyword
       method_of_diagnosis:
         type: keyword
       morphology:

--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -94,6 +94,8 @@ properties:
         type: keyword
       colon_polyps_history:
         type: keyword
+      days_to_diagnosis:
+        type: long
       days_to_hiv_diagnosis:
         type: long
       days_to_last_follow_up:
@@ -114,6 +116,16 @@ properties:
         type: keyword
       hpv_status:
         type: keyword
+      icd_10_code:
+        type: keyword
+      igcccg_stage:
+        type: keyword
+      inss_stage:
+        type: keyword
+      international_prognostic_index:
+        type: keyword
+      iss_stage:
+        type: keyword
       last_known_disease_status:
         type: keyword
       laterality:
@@ -125,6 +137,8 @@ properties:
       lymph_nodes_positive:
         type: long
       lymphatic_invasion_present:
+        type: keyword
+      masaoka_stage:
         type: keyword
       method_of_diagnosis:
         type: keyword
@@ -138,6 +152,8 @@ properties:
         type: keyword
       primary_diagnosis:
         type: keyword
+      primary_gleason_grade:
+        type: keyword
       prior_malignancy:
         type: keyword
       prior_treatment:
@@ -146,11 +162,15 @@ properties:
         type: keyword
       residual_disease:
         type: keyword
+      secondary_gleason_grade:
+        type: keyword
       site_of_resection_or_biopsy:
         type: keyword
       state:
         type: keyword
       submitter_id:
+        type: keyword
+      synchronous_malignancy:
         type: keyword
       tissue_or_organ_of_origin:
         type: keyword
@@ -462,6 +482,10 @@ properties:
       symbol:
         type: keyword
     type: nested
+  index_date:
+    type: keyword
+  lost_to_followup:
+    type: keyword
   primary_site:
     copy_to:
     - case_autocomplete

--- a/es-models/cnv_centric/cnv_centric.mapping.yaml
+++ b/es-models/cnv_centric/cnv_centric.mapping.yaml
@@ -118,6 +118,8 @@ properties:
                 type: long
               classification_of_tumor:
                 type: keyword
+              cog_renal_stage:
+                type: keyword
               colon_polyps_history:
                 type: keyword
               days_to_diagnosis:
@@ -234,6 +236,8 @@ properties:
               tumor_stage:
                 type: keyword
               vascular_invasion_present:
+                type: keyword
+              vascular_invasion_type:
                 type: keyword
               year_of_diagnosis:
                 type: long

--- a/es-models/cnv_centric/cnv_centric.mapping.yaml
+++ b/es-models/cnv_centric/cnv_centric.mapping.yaml
@@ -56,6 +56,8 @@ properties:
             type: long
           demographic:
             properties:
+              age_at_index:
+                type: long
               cause_of_death:
                 type: keyword
               days_to_birth:
@@ -210,6 +212,10 @@ properties:
                     type: long
                   days_to_treatment_start:
                     type: long
+                  initial_disease_status:
+                    type: keyword
+                  regimen_or_line_of_therapy:
+                    type: keyword
                   state:
                     type: keyword
                   submitter_id:

--- a/es-models/cnv_centric/cnv_centric.mapping.yaml
+++ b/es-models/cnv_centric/cnv_centric.mapping.yaml
@@ -166,6 +166,8 @@ properties:
                 type: keyword
               masaoka_stage:
                 type: keyword
+              metastasis_at_diagnosis:
+                type: keyword
               method_of_diagnosis:
                 type: keyword
               morphology:

--- a/es-models/cnv_centric/cnv_centric.mapping.yaml
+++ b/es-models/cnv_centric/cnv_centric.mapping.yaml
@@ -120,6 +120,8 @@ properties:
                 type: keyword
               colon_polyps_history:
                 type: keyword
+              days_to_diagnosis:
+                type: long
               days_to_hiv_diagnosis:
                 type: long
               days_to_last_follow_up:
@@ -140,6 +142,16 @@ properties:
                 type: keyword
               hpv_status:
                 type: keyword
+              icd_10_code:
+                type: keyword
+              igcccg_stage:
+                type: keyword
+              inss_stage:
+                type: keyword
+              international_prognostic_index:
+                type: keyword
+              iss_stage:
+                type: keyword
               last_known_disease_status:
                 type: keyword
               laterality:
@@ -151,6 +163,8 @@ properties:
               lymph_nodes_positive:
                 type: long
               lymphatic_invasion_present:
+                type: keyword
+              masaoka_stage:
                 type: keyword
               method_of_diagnosis:
                 type: keyword
@@ -164,6 +178,8 @@ properties:
                 type: keyword
               primary_diagnosis:
                 type: keyword
+              primary_gleason_grade:
+                type: keyword
               prior_malignancy:
                 type: keyword
               prior_treatment:
@@ -172,11 +188,15 @@ properties:
                 type: keyword
               residual_disease:
                 type: keyword
+              secondary_gleason_grade:
+                type: keyword
               site_of_resection_or_biopsy:
                 type: keyword
               state:
                 type: keyword
               submitter_id:
+                type: keyword
+              synchronous_malignancy:
                 type: keyword
               tissue_or_organ_of_origin:
                 type: keyword
@@ -268,6 +288,10 @@ properties:
               submitter_id:
                 type: keyword
             type: nested
+          index_date:
+            type: keyword
+          lost_to_followup:
+            type: keyword
           observation:
             properties:
               observation_id:

--- a/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
+++ b/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
@@ -76,6 +76,8 @@ properties:
             type: long
           classification_of_tumor:
             type: keyword
+          cog_renal_stage:
+            type: keyword
           colon_polyps_history:
             type: keyword
           days_to_diagnosis:
@@ -192,6 +194,8 @@ properties:
           tumor_stage:
             type: keyword
           vascular_invasion_present:
+            type: keyword
+          vascular_invasion_type:
             type: keyword
           year_of_diagnosis:
             type: long

--- a/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
+++ b/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
@@ -78,6 +78,8 @@ properties:
             type: keyword
           colon_polyps_history:
             type: keyword
+          days_to_diagnosis:
+            type: long
           days_to_hiv_diagnosis:
             type: long
           days_to_last_follow_up:
@@ -98,6 +100,16 @@ properties:
             type: keyword
           hpv_status:
             type: keyword
+          icd_10_code:
+            type: keyword
+          igcccg_stage:
+            type: keyword
+          inss_stage:
+            type: keyword
+          international_prognostic_index:
+            type: keyword
+          iss_stage:
+            type: keyword
           last_known_disease_status:
             type: keyword
           laterality:
@@ -109,6 +121,8 @@ properties:
           lymph_nodes_positive:
             type: long
           lymphatic_invasion_present:
+            type: keyword
+          masaoka_stage:
             type: keyword
           method_of_diagnosis:
             type: keyword
@@ -122,6 +136,8 @@ properties:
             type: keyword
           primary_diagnosis:
             type: keyword
+          primary_gleason_grade:
+            type: keyword
           prior_malignancy:
             type: keyword
           prior_treatment:
@@ -130,11 +146,15 @@ properties:
             type: keyword
           residual_disease:
             type: keyword
+          secondary_gleason_grade:
+            type: keyword
           site_of_resection_or_biopsy:
             type: keyword
           state:
             type: keyword
           submitter_id:
+            type: keyword
+          synchronous_malignancy:
             type: keyword
           tissue_or_organ_of_origin:
             type: keyword
@@ -226,6 +246,10 @@ properties:
           submitter_id:
             type: keyword
         type: nested
+      index_date:
+        type: keyword
+      lost_to_followup:
+        type: keyword
       observation:
         properties:
           observation_id:

--- a/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
+++ b/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
@@ -124,6 +124,8 @@ properties:
             type: keyword
           masaoka_stage:
             type: keyword
+          metastasis_at_diagnosis:
+            type: keyword
           method_of_diagnosis:
             type: keyword
           morphology:

--- a/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
+++ b/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
@@ -14,6 +14,8 @@ properties:
         type: long
       demographic:
         properties:
+          age_at_index:
+            type: long
           cause_of_death:
             type: keyword
           days_to_birth:
@@ -168,6 +170,10 @@ properties:
                 type: long
               days_to_treatment_start:
                 type: long
+              initial_disease_status:
+                type: keyword
+              regimen_or_line_of_therapy:
+                type: keyword
               state:
                 type: keyword
               submitter_id:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -126,6 +126,8 @@ properties:
             type: long
           classification_of_tumor:
             type: keyword
+          cog_renal_stage:
+            type: keyword
           colon_polyps_history:
             type: keyword
           days_to_diagnosis:
@@ -242,6 +244,8 @@ properties:
           tumor_stage:
             type: keyword
           vascular_invasion_present:
+            type: keyword
+          vascular_invasion_type:
             type: keyword
           year_of_diagnosis:
             type: long

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -64,6 +64,8 @@ properties:
         type: long
       demographic:
         properties:
+          age_at_index:
+            type: long
           cause_of_death:
             type: keyword
           days_to_birth:
@@ -218,6 +220,10 @@ properties:
                 type: long
               days_to_treatment_start:
                 type: long
+              initial_disease_status:
+                type: keyword
+              regimen_or_line_of_therapy:
+                type: keyword
               state:
                 type: keyword
               submitter_id:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -128,6 +128,8 @@ properties:
             type: keyword
           colon_polyps_history:
             type: keyword
+          days_to_diagnosis:
+            type: long
           days_to_hiv_diagnosis:
             type: long
           days_to_last_follow_up:
@@ -148,6 +150,16 @@ properties:
             type: keyword
           hpv_status:
             type: keyword
+          icd_10_code:
+            type: keyword
+          igcccg_stage:
+            type: keyword
+          inss_stage:
+            type: keyword
+          international_prognostic_index:
+            type: keyword
+          iss_stage:
+            type: keyword
           last_known_disease_status:
             type: keyword
           laterality:
@@ -159,6 +171,8 @@ properties:
           lymph_nodes_positive:
             type: long
           lymphatic_invasion_present:
+            type: keyword
+          masaoka_stage:
             type: keyword
           method_of_diagnosis:
             type: keyword
@@ -172,6 +186,8 @@ properties:
             type: keyword
           primary_diagnosis:
             type: keyword
+          primary_gleason_grade:
+            type: keyword
           prior_malignancy:
             type: keyword
           prior_treatment:
@@ -180,11 +196,15 @@ properties:
             type: keyword
           residual_disease:
             type: keyword
+          secondary_gleason_grade:
+            type: keyword
           site_of_resection_or_biopsy:
             type: keyword
           state:
             type: keyword
           submitter_id:
+            type: keyword
+          synchronous_malignancy:
             type: keyword
           tissue_or_organ_of_origin:
             type: keyword
@@ -276,6 +296,10 @@ properties:
           submitter_id:
             type: keyword
         type: nested
+      index_date:
+        type: keyword
+      lost_to_followup:
+        type: keyword
       primary_site:
         type: keyword
       project:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -174,6 +174,8 @@ properties:
             type: keyword
           masaoka_stage:
             type: keyword
+          metastasis_at_diagnosis:
+            type: keyword
           method_of_diagnosis:
             type: keyword
           morphology:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -229,6 +229,8 @@ properties:
                 type: keyword
               colon_polyps_history:
                 type: keyword
+              days_to_diagnosis:
+                type: long
               days_to_hiv_diagnosis:
                 type: long
               days_to_last_follow_up:
@@ -249,6 +251,16 @@ properties:
                 type: keyword
               hpv_status:
                 type: keyword
+              icd_10_code:
+                type: keyword
+              igcccg_stage:
+                type: keyword
+              inss_stage:
+                type: keyword
+              international_prognostic_index:
+                type: keyword
+              iss_stage:
+                type: keyword
               last_known_disease_status:
                 type: keyword
               laterality:
@@ -260,6 +272,8 @@ properties:
               lymph_nodes_positive:
                 type: long
               lymphatic_invasion_present:
+                type: keyword
+              masaoka_stage:
                 type: keyword
               method_of_diagnosis:
                 type: keyword
@@ -273,6 +287,8 @@ properties:
                 type: keyword
               primary_diagnosis:
                 type: keyword
+              primary_gleason_grade:
+                type: keyword
               prior_malignancy:
                 type: keyword
               prior_treatment:
@@ -281,11 +297,15 @@ properties:
                 type: keyword
               residual_disease:
                 type: keyword
+              secondary_gleason_grade:
+                type: keyword
               site_of_resection_or_biopsy:
                 type: keyword
               state:
                 type: keyword
               submitter_id:
+                type: keyword
+              synchronous_malignancy:
                 type: keyword
               tissue_or_organ_of_origin:
                 type: keyword
@@ -377,6 +397,10 @@ properties:
               submitter_id:
                 type: keyword
             type: nested
+          index_date:
+            type: keyword
+          lost_to_followup:
+            type: keyword
           observation:
             properties:
               acl:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -165,6 +165,8 @@ properties:
             type: long
           demographic:
             properties:
+              age_at_index:
+                type: long
               cause_of_death:
                 type: keyword
               days_to_birth:
@@ -319,6 +321,10 @@ properties:
                     type: long
                   days_to_treatment_start:
                     type: long
+                  initial_disease_status:
+                    type: keyword
+                  regimen_or_line_of_therapy:
+                    type: keyword
                   state:
                     type: keyword
                   submitter_id:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -275,6 +275,8 @@ properties:
                 type: keyword
               masaoka_stage:
                 type: keyword
+              metastasis_at_diagnosis:
+                type: keyword
               method_of_diagnosis:
                 type: keyword
               morphology:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -227,6 +227,8 @@ properties:
                 type: long
               classification_of_tumor:
                 type: keyword
+              cog_renal_stage:
+                type: keyword
               colon_polyps_history:
                 type: keyword
               days_to_diagnosis:
@@ -343,6 +345,8 @@ properties:
               tumor_stage:
                 type: keyword
               vascular_invasion_present:
+                type: keyword
+              vascular_invasion_type:
                 type: keyword
               year_of_diagnosis:
                 type: long

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -80,6 +80,8 @@ properties:
             type: keyword
           colon_polyps_history:
             type: keyword
+          days_to_diagnosis:
+            type: long
           days_to_hiv_diagnosis:
             type: long
           days_to_last_follow_up:
@@ -100,6 +102,16 @@ properties:
             type: keyword
           hpv_status:
             type: keyword
+          icd_10_code:
+            type: keyword
+          igcccg_stage:
+            type: keyword
+          inss_stage:
+            type: keyword
+          international_prognostic_index:
+            type: keyword
+          iss_stage:
+            type: keyword
           last_known_disease_status:
             type: keyword
           laterality:
@@ -111,6 +123,8 @@ properties:
           lymph_nodes_positive:
             type: long
           lymphatic_invasion_present:
+            type: keyword
+          masaoka_stage:
             type: keyword
           method_of_diagnosis:
             type: keyword
@@ -124,6 +138,8 @@ properties:
             type: keyword
           primary_diagnosis:
             type: keyword
+          primary_gleason_grade:
+            type: keyword
           prior_malignancy:
             type: keyword
           prior_treatment:
@@ -132,11 +148,15 @@ properties:
             type: keyword
           residual_disease:
             type: keyword
+          secondary_gleason_grade:
+            type: keyword
           site_of_resection_or_biopsy:
             type: keyword
           state:
             type: keyword
           submitter_id:
+            type: keyword
+          synchronous_malignancy:
             type: keyword
           tissue_or_organ_of_origin:
             type: keyword
@@ -228,6 +248,10 @@ properties:
           submitter_id:
             type: keyword
         type: nested
+      index_date:
+        type: keyword
+      lost_to_followup:
+        type: keyword
       observation:
         properties:
           acl:

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -78,6 +78,8 @@ properties:
             type: long
           classification_of_tumor:
             type: keyword
+          cog_renal_stage:
+            type: keyword
           colon_polyps_history:
             type: keyword
           days_to_diagnosis:
@@ -194,6 +196,8 @@ properties:
           tumor_stage:
             type: keyword
           vascular_invasion_present:
+            type: keyword
+          vascular_invasion_type:
             type: keyword
           year_of_diagnosis:
             type: long

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -126,6 +126,8 @@ properties:
             type: keyword
           masaoka_stage:
             type: keyword
+          metastasis_at_diagnosis:
+            type: keyword
           method_of_diagnosis:
             type: keyword
           morphology:

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -16,6 +16,8 @@ properties:
         type: long
       demographic:
         properties:
+          age_at_index:
+            type: long
           cause_of_death:
             type: keyword
           days_to_birth:
@@ -170,6 +172,10 @@ properties:
                 type: long
               days_to_treatment_start:
                 type: long
+              initial_disease_status:
+                type: keyword
+              regimen_or_line_of_therapy:
+                type: keyword
               state:
                 type: keyword
               submitter_id:


### PR DESCRIPTION
Bring the following fields that now have data into viz indices:
```
index_date
lost_to_followup
demographic.age_at_index
diagnoses.metastasis_at_diagnosis
diagnoses.secondary_gleason_grade
diagnoses.synchronous_malignancy
diagnoses.igcccg_stage
diagnoses.masaoka_stage
diagnoses.international_prognostic_index
diagnoses.primary_gleason_grade
diagnoses.cog_renal_stage
diagnoses.iss_stage
diagnoses.inss_stage
diagnoses.icd_10_code
diagnoses.vascular_invasion_type
diagnoses.days_to_diagnosis
diagnoses.treatments.initial_disease_status
diagnoses.treatments.regimen_or_line_of_therapy
```