### PR TITLE
DEV-157 remove ACLs and src_vcf_id

### DIFF
--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -435,8 +435,6 @@ properties:
             type: keyword
           observation:
             properties:
-              acl:
-                type: keyword
               center:
                 type: keyword
               input_bam_file:
@@ -552,8 +550,6 @@ properties:
     properties:
       sample_type:
         type: keyword
-  ssm_acl:
-    type: keyword
   state:
     type: keyword
   submitter_id:

--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -473,8 +473,6 @@ properties:
                     type: keyword
                   tumor_sample_uuid:
                     type: keyword
-              src_vcf_id:
-                type: keyword
               tumor_genotype:
                 properties:
                   tumor_seq_allele1:

--- a/es-models/cnv_centric/cnv_centric.mapping.yaml
+++ b/es-models/cnv_centric/cnv_centric.mapping.yaml
@@ -367,8 +367,6 @@ properties:
             properties:
               sample_type:
                 type: keyword
-          ssm_acl:
-            type: keyword
           state:
             type: keyword
           submitter_id:

--- a/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
+++ b/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
@@ -325,8 +325,6 @@ properties:
         properties:
           sample_type:
             type: keyword
-      ssm_acl:
-        type: keyword
       state:
         type: keyword
       submitter_id:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -493,8 +493,6 @@ properties:
                     type: keyword
                   tumor_sample_uuid:
                     type: keyword
-              src_vcf_id:
-                type: keyword
               tumor_genotype:
                 properties:
                   tumor_seq_allele1:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -455,8 +455,6 @@ properties:
             type: keyword
           observation:
             properties:
-              acl:
-                type: keyword
               center:
                 type: keyword
               input_bam_file:
@@ -527,8 +525,6 @@ properties:
           tumor_allele:
             type: keyword
         type: nested
-      ssm_acl:
-        type: keyword
       state:
         type: keyword
       submitter_id:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -469,8 +469,6 @@ properties:
                     type: keyword
                   tumor_sample_uuid:
                     type: keyword
-              src_vcf_id:
-                type: keyword
               tumor_genotype:
                 properties:
                   tumor_seq_allele1:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -431,8 +431,6 @@ properties:
             type: keyword
           observation:
             properties:
-              acl:
-                type: keyword
               center:
                 type: keyword
               input_bam_file:
@@ -522,8 +520,6 @@ properties:
             properties:
               sample_type:
                 type: keyword
-          ssm_acl:
-            type: keyword
           state:
             type: keyword
           submitter_id:

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -282,8 +282,6 @@ properties:
         type: keyword
       observation:
         properties:
-          acl:
-            type: keyword
           center:
             type: keyword
           input_bam_file:
@@ -373,8 +371,6 @@ properties:
         properties:
           sample_type:
             type: keyword
-      ssm_acl:
-        type: keyword
       state:
         type: keyword
       submitter_id:

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -320,8 +320,6 @@ properties:
                 type: keyword
               tumor_sample_uuid:
                 type: keyword
-          src_vcf_id:
-            type: keyword
           tumor_genotype:
             properties:
               tumor_seq_allele1:


### PR DESCRIPTION
Remove the `acl` and `ssm_acl` fields as we are no longer writing those in DAVE-CA Phase 1. Remove the `src_vcf_id` field (see DEV-29) as it is not provided in the MAFs we're indexing going forward.