### PR TITLE
DEV-137 add new dr23 fields to viz mappings

### DIFF
--- a/es-models/case_centric/case_centric.mapping.yaml
+++ b/es-models/case_centric/case_centric.mapping.yaml
@@ -26,12 +26,18 @@ properties:
     copy_to:
     - case_autocomplete
     type: keyword
+  consent_type:
+    type: keyword
+  days_to_consent:
+    type: long
   days_to_index:
     type: long
   demographic:
     properties:
       age_at_index:
         type: long
+      age_is_obfuscated:
+        type: keyword
       cause_of_death:
         type: keyword
       days_to_birth:
@@ -146,6 +152,8 @@ properties:
         type: long
       ldh_normal_range_upper:
         type: long
+      lymph_node_involved_site:
+        type: keyword
       lymph_nodes_positive:
         type: long
       lymph_nodes_tested:
@@ -155,6 +163,8 @@ properties:
       masaoka_stage:
         type: keyword
       metastasis_at_diagnosis:
+        type: keyword
+      metastasis_at_diagnosis_site:
         type: keyword
       method_of_diagnosis:
         type: keyword
@@ -168,6 +178,10 @@ properties:
         type: keyword
       perineural_invasion_present:
         type: keyword
+      peripancreatic_lymph_nodes_positive:
+        type: keyword
+      peripancreatic_lymph_nodes_tested:
+        type: long
       primary_diagnosis:
         type: keyword
       primary_gleason_grade:
@@ -200,6 +214,8 @@ properties:
             type: long
           initial_disease_status:
             type: keyword
+          number_of_cycles:
+            type: long
           regimen_or_line_of_therapy:
             type: keyword
           state:
@@ -210,6 +226,8 @@ properties:
             type: keyword
           treatment_anatomic_site:
             type: keyword
+          treatment_dose:
+            type: long
           treatment_id:
             type: keyword
           treatment_intent_type:
@@ -240,6 +258,8 @@ properties:
     type: keyword
   exposures:
     properties:
+      alcohol_days_per_week:
+        type: long
       alcohol_history:
         type: keyword
       alcohol_intensity:

--- a/es-models/cnv_centric/cnv_centric.mapping.yaml
+++ b/es-models/cnv_centric/cnv_centric.mapping.yaml
@@ -52,12 +52,18 @@ properties:
             type: keyword
           case_id:
             type: keyword
+          consent_type:
+            type: keyword
+          days_to_consent:
+            type: long
           days_to_index:
             type: long
           demographic:
             properties:
               age_at_index:
                 type: long
+              age_is_obfuscated:
+                type: keyword
               cause_of_death:
                 type: keyword
               days_to_birth:
@@ -172,6 +178,8 @@ properties:
                 type: long
               ldh_normal_range_upper:
                 type: long
+              lymph_node_involved_site:
+                type: keyword
               lymph_nodes_positive:
                 type: long
               lymph_nodes_tested:
@@ -181,6 +189,8 @@ properties:
               masaoka_stage:
                 type: keyword
               metastasis_at_diagnosis:
+                type: keyword
+              metastasis_at_diagnosis_site:
                 type: keyword
               method_of_diagnosis:
                 type: keyword
@@ -194,6 +204,10 @@ properties:
                 type: keyword
               perineural_invasion_present:
                 type: keyword
+              peripancreatic_lymph_nodes_positive:
+                type: keyword
+              peripancreatic_lymph_nodes_tested:
+                type: long
               primary_diagnosis:
                 type: keyword
               primary_gleason_grade:
@@ -226,6 +240,8 @@ properties:
                     type: long
                   initial_disease_status:
                     type: keyword
+                  number_of_cycles:
+                    type: long
                   regimen_or_line_of_therapy:
                     type: keyword
                   state:
@@ -236,6 +252,8 @@ properties:
                     type: keyword
                   treatment_anatomic_site:
                     type: keyword
+                  treatment_dose:
+                    type: long
                   treatment_id:
                     type: keyword
                   treatment_intent_type:
@@ -264,6 +282,8 @@ properties:
             type: keyword
           exposures:
             properties:
+              alcohol_days_per_week:
+                type: long
               alcohol_history:
                 type: keyword
               alcohol_intensity:

--- a/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
+++ b/es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml
@@ -10,12 +10,18 @@ properties:
         type: keyword
       case_id:
         type: keyword
+      consent_type:
+        type: keyword
+      days_to_consent:
+        type: long
       days_to_index:
         type: long
       demographic:
         properties:
           age_at_index:
             type: long
+          age_is_obfuscated:
+            type: keyword
           cause_of_death:
             type: keyword
           days_to_birth:
@@ -130,6 +136,8 @@ properties:
             type: long
           ldh_normal_range_upper:
             type: long
+          lymph_node_involved_site:
+            type: keyword
           lymph_nodes_positive:
             type: long
           lymph_nodes_tested:
@@ -139,6 +147,8 @@ properties:
           masaoka_stage:
             type: keyword
           metastasis_at_diagnosis:
+            type: keyword
+          metastasis_at_diagnosis_site:
             type: keyword
           method_of_diagnosis:
             type: keyword
@@ -152,6 +162,10 @@ properties:
             type: keyword
           perineural_invasion_present:
             type: keyword
+          peripancreatic_lymph_nodes_positive:
+            type: keyword
+          peripancreatic_lymph_nodes_tested:
+            type: long
           primary_diagnosis:
             type: keyword
           primary_gleason_grade:
@@ -184,6 +198,8 @@ properties:
                 type: long
               initial_disease_status:
                 type: keyword
+              number_of_cycles:
+                type: long
               regimen_or_line_of_therapy:
                 type: keyword
               state:
@@ -194,6 +210,8 @@ properties:
                 type: keyword
               treatment_anatomic_site:
                 type: keyword
+              treatment_dose:
+                type: long
               treatment_id:
                 type: keyword
               treatment_intent_type:
@@ -222,6 +240,8 @@ properties:
         type: keyword
       exposures:
         properties:
+          alcohol_days_per_week:
+            type: long
           alcohol_history:
             type: keyword
           alcohol_intensity:

--- a/es-models/gene_centric/gene_centric.mapping.yaml
+++ b/es-models/gene_centric/gene_centric.mapping.yaml
@@ -60,12 +60,18 @@ properties:
           start_position:
             type: long
         type: nested
+      consent_type:
+        type: keyword
+      days_to_consent:
+        type: long
       days_to_index:
         type: long
       demographic:
         properties:
           age_at_index:
             type: long
+          age_is_obfuscated:
+            type: keyword
           cause_of_death:
             type: keyword
           days_to_birth:
@@ -180,6 +186,8 @@ properties:
             type: long
           ldh_normal_range_upper:
             type: long
+          lymph_node_involved_site:
+            type: keyword
           lymph_nodes_positive:
             type: long
           lymph_nodes_tested:
@@ -189,6 +197,8 @@ properties:
           masaoka_stage:
             type: keyword
           metastasis_at_diagnosis:
+            type: keyword
+          metastasis_at_diagnosis_site:
             type: keyword
           method_of_diagnosis:
             type: keyword
@@ -202,6 +212,10 @@ properties:
             type: keyword
           perineural_invasion_present:
             type: keyword
+          peripancreatic_lymph_nodes_positive:
+            type: keyword
+          peripancreatic_lymph_nodes_tested:
+            type: long
           primary_diagnosis:
             type: keyword
           primary_gleason_grade:
@@ -234,6 +248,8 @@ properties:
                 type: long
               initial_disease_status:
                 type: keyword
+              number_of_cycles:
+                type: long
               regimen_or_line_of_therapy:
                 type: keyword
               state:
@@ -244,6 +260,8 @@ properties:
                 type: keyword
               treatment_anatomic_site:
                 type: keyword
+              treatment_dose:
+                type: long
               treatment_id:
                 type: keyword
               treatment_intent_type:
@@ -272,6 +290,8 @@ properties:
         type: keyword
       exposures:
         properties:
+          alcohol_days_per_week:
+            type: long
           alcohol_history:
             type: keyword
           alcohol_intensity:

--- a/es-models/ssm_centric/ssm_centric.mapping.yaml
+++ b/es-models/ssm_centric/ssm_centric.mapping.yaml
@@ -161,12 +161,18 @@ properties:
             type: keyword
           case_id:
             type: keyword
+          consent_type:
+            type: keyword
+          days_to_consent:
+            type: long
           days_to_index:
             type: long
           demographic:
             properties:
               age_at_index:
                 type: long
+              age_is_obfuscated:
+                type: keyword
               cause_of_death:
                 type: keyword
               days_to_birth:
@@ -281,6 +287,8 @@ properties:
                 type: long
               ldh_normal_range_upper:
                 type: long
+              lymph_node_involved_site:
+                type: keyword
               lymph_nodes_positive:
                 type: long
               lymph_nodes_tested:
@@ -290,6 +298,8 @@ properties:
               masaoka_stage:
                 type: keyword
               metastasis_at_diagnosis:
+                type: keyword
+              metastasis_at_diagnosis_site:
                 type: keyword
               method_of_diagnosis:
                 type: keyword
@@ -303,6 +313,10 @@ properties:
                 type: keyword
               perineural_invasion_present:
                 type: keyword
+              peripancreatic_lymph_nodes_positive:
+                type: keyword
+              peripancreatic_lymph_nodes_tested:
+                type: long
               primary_diagnosis:
                 type: keyword
               primary_gleason_grade:
@@ -335,6 +349,8 @@ properties:
                     type: long
                   initial_disease_status:
                     type: keyword
+                  number_of_cycles:
+                    type: long
                   regimen_or_line_of_therapy:
                     type: keyword
                   state:
@@ -345,6 +361,8 @@ properties:
                     type: keyword
                   treatment_anatomic_site:
                     type: keyword
+                  treatment_dose:
+                    type: long
                   treatment_id:
                     type: keyword
                   treatment_intent_type:
@@ -373,6 +391,8 @@ properties:
             type: keyword
           exposures:
             properties:
+              alcohol_days_per_week:
+                type: long
               alcohol_history:
                 type: keyword
               alcohol_intensity:

--- a/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
+++ b/es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml
@@ -12,12 +12,18 @@ properties:
         type: keyword
       case_id:
         type: keyword
+      consent_type:
+        type: keyword
+      days_to_consent:
+        type: long
       days_to_index:
         type: long
       demographic:
         properties:
           age_at_index:
             type: long
+          age_is_obfuscated:
+            type: keyword
           cause_of_death:
             type: keyword
           days_to_birth:
@@ -132,6 +138,8 @@ properties:
             type: long
           ldh_normal_range_upper:
             type: long
+          lymph_node_involved_site:
+            type: keyword
           lymph_nodes_positive:
             type: long
           lymph_nodes_tested:
@@ -141,6 +149,8 @@ properties:
           masaoka_stage:
             type: keyword
           metastasis_at_diagnosis:
+            type: keyword
+          metastasis_at_diagnosis_site:
             type: keyword
           method_of_diagnosis:
             type: keyword
@@ -154,6 +164,10 @@ properties:
             type: keyword
           perineural_invasion_present:
             type: keyword
+          peripancreatic_lymph_nodes_positive:
+            type: keyword
+          peripancreatic_lymph_nodes_tested:
+            type: long
           primary_diagnosis:
             type: keyword
           primary_gleason_grade:
@@ -186,6 +200,8 @@ properties:
                 type: long
               initial_disease_status:
                 type: keyword
+              number_of_cycles:
+                type: long
               regimen_or_line_of_therapy:
                 type: keyword
               state:
@@ -196,6 +212,8 @@ properties:
                 type: keyword
               treatment_anatomic_site:
                 type: keyword
+              treatment_dose:
+                type: long
               treatment_id:
                 type: keyword
               treatment_intent_type:
@@ -224,6 +242,8 @@ properties:
         type: keyword
       exposures:
         properties:
+          alcohol_days_per_week:
+            type: long
           alcohol_history:
             type: keyword
           alcohol_intensity:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 setup(
     name="gdcmodels",
     setup_requires=["setuptools_scm"],
-    use_scm_version={"local_scheme": "dirty-tag"},
+    use_scm_version={"local_scheme": "dirty-tag", "fallback_version": "local"},
     packages=find_packages(
         exclude=["scripts", "*-models", "*.tests", "*.tests.*", "tests.*", "tests"]
     ),


### PR DESCRIPTION
Add fields that were populated for the first time in DR23 to the visualization index mappings. I confirmed in my dev cluster that mutation indexer doesn't prompt to extend the blacklist when building the DR23 graph using these mappings. I also checked the resulting case_centric index and confirmed that the new fields all have values.

Tweak setuptools_scm config so the mutation indexer deployment won't bomb out if pip doesn't clone the full Git history. This is a follow-up to https://github.com/NCI-GDC/gdc-models/pull/129 that we'll have to keep in mind if we try to version our software automatically while still pulling libraries from Git.