### PR TITLE
DEV-213 set huge nested objects limit for legacy

### DIFF
--- a/es-models/gdc_legacy_graph/settings.yaml
+++ b/es-models/gdc_legacy_graph/settings.yaml
@@ -10,5 +10,6 @@ analysis:
       min_gram: 2
       side: front
       type: edge_ngram
+index.mapping.nested_objects.limit: 100000000
 index.max_result_window: 100000000
 mapping.nested_fields.limit: 150


### PR DESCRIPTION
Use the same huge value for `index.mapping.nested_objects.limit` in the legacy index that we do in the other indices. Make it possible to populate the legacy graph index on ES7.