### PR TITLE
DEV-200 add new very bad fish fields to graph models

### DIFF
--- a/es-models/gdc_from_graph/annotation.mapping.yaml
+++ b/es-models/gdc_from_graph/annotation.mapping.yaml
@@ -15,7 +15,8 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   annotation_id:
-    copy_to: annotation_autocomplete
+    copy_to:
+    - annotation_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   case_id:

--- a/es-models/gdc_from_graph/case.mapping.yaml
+++ b/es-models/gdc_from_graph/case.mapping.yaml
@@ -72,7 +72,8 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   case_id:
-    copy_to: case_autocomplete
+    copy_to:
+    - case_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   consent_type:
@@ -288,6 +289,9 @@ properties:
       diagnosis_id:
         normalizer: clinical_normalizer
         type: keyword
+      eln_risk_classification:
+        normalizer: clinical_normalizer
+        type: keyword
       enneking_msts_grade:
         normalizer: clinical_normalizer
         type: keyword
@@ -465,10 +469,16 @@ properties:
       residual_disease:
         normalizer: clinical_normalizer
         type: keyword
+      satellite_nodule_present:
+        normalizer: clinical_normalizer
+        type: keyword
       secondary_gleason_grade:
         normalizer: clinical_normalizer
         type: keyword
       site_of_resection_or_biopsy:
+        normalizer: clinical_normalizer
+        type: keyword
+      sites_of_involvement:
         normalizer: clinical_normalizer
         type: keyword
       state:
@@ -589,6 +599,12 @@ properties:
       weiss_assessment_score:
         normalizer: clinical_normalizer
         type: keyword
+      who_cns_grade:
+        normalizer: clinical_normalizer
+        type: keyword
+      who_nte_grade:
+        normalizer: clinical_normalizer
+        type: keyword
       wilms_tumor_histologic_subtype:
         normalizer: clinical_normalizer
         type: keyword
@@ -613,6 +629,9 @@ properties:
         normalizer: clinical_normalizer
         type: keyword
       alcohol_intensity:
+        normalizer: clinical_normalizer
+        type: keyword
+      alcohol_type:
         normalizer: clinical_normalizer
         type: keyword
       asbestos_exposure:
@@ -655,6 +674,8 @@ properties:
       secondhand_smoke_as_child:
         normalizer: clinical_normalizer
         type: keyword
+      smokeless_tobacco_quit_age:
+        type: long
       smoking_frequency:
         normalizer: clinical_normalizer
         type: keyword
@@ -873,6 +894,9 @@ properties:
                     normalizer: clinical_normalizer
                     type: keyword
                   base_caller_version:
+                    normalizer: clinical_normalizer
+                    type: keyword
+                  chipseq_target:
                     normalizer: clinical_normalizer
                     type: keyword
                   created_datetime:
@@ -1667,7 +1691,13 @@ properties:
         type: keyword
       hiv_viral_load:
         type: long
+      hormonal_contraceptive_type:
+        normalizer: clinical_normalizer
+        type: keyword
       hormonal_contraceptive_use:
+        normalizer: clinical_normalizer
+        type: keyword
+      hormone_replacement_therapy_type:
         normalizer: clinical_normalizer
         type: keyword
       hpv_positive_type:
@@ -1705,6 +1735,8 @@ properties:
           biospecimen_type:
             normalizer: clinical_normalizer
             type: keyword
+          biospecimen_volume:
+            type: long
           blood_test_normal_range_lower:
             type: long
           blood_test_normal_range_upper:
@@ -1753,6 +1785,10 @@ properties:
           mismatch_repair_mutation:
             normalizer: clinical_normalizer
             type: keyword
+          mitotic_count:
+            type: long
+          mitotic_total_area:
+            type: long
           molecular_analysis_method:
             normalizer: clinical_normalizer
             type: keyword
@@ -1814,6 +1850,9 @@ properties:
       pancreatitis_onset_year:
         type: long
       pregnancy_outcome:
+        normalizer: clinical_normalizer
+        type: keyword
+      procedures_performed:
         normalizer: clinical_normalizer
         type: keyword
       progression_or_recurrence:
@@ -2024,7 +2063,8 @@ properties:
               aliquots:
                 properties:
                   aliquot_id:
-                    copy_to: case_autocomplete
+                    copy_to:
+                    - case_autocomplete
                     normalizer: clinical_normalizer
                     type: keyword
                   aliquot_quantity:
@@ -2144,7 +2184,8 @@ properties:
                     normalizer: clinical_normalizer
                     type: keyword
                   submitter_id:
-                    copy_to: case_autocomplete
+                    copy_to:
+                    - case_autocomplete
                     type: keyword
                   updated_datetime:
                     normalizer: clinical_normalizer
@@ -2153,7 +2194,8 @@ properties:
               amount:
                 type: long
               analyte_id:
-                copy_to: case_autocomplete
+                copy_to:
+                - case_autocomplete
                 normalizer: clinical_normalizer
                 type: keyword
               analyte_quantity:
@@ -2234,7 +2276,8 @@ properties:
                 normalizer: clinical_normalizer
                 type: keyword
               submitter_id:
-                copy_to: case_autocomplete
+                copy_to:
+                - case_autocomplete
                 type: keyword
               updated_datetime:
                 normalizer: clinical_normalizer
@@ -2321,7 +2364,8 @@ properties:
             normalizer: clinical_normalizer
             type: keyword
           portion_id:
-            copy_to: case_autocomplete
+            copy_to:
+            - case_autocomplete
             normalizer: clinical_normalizer
             type: keyword
           portion_number:
@@ -2426,14 +2470,16 @@ properties:
                 normalizer: clinical_normalizer
                 type: keyword
               slide_id:
-                copy_to: case_autocomplete
+                copy_to:
+                - case_autocomplete
                 normalizer: clinical_normalizer
                 type: keyword
               state:
                 normalizer: clinical_normalizer
                 type: keyword
               submitter_id:
-                copy_to: case_autocomplete
+                copy_to:
+                - case_autocomplete
                 type: keyword
               tissue_microarray_coordinates:
                 normalizer: clinical_normalizer
@@ -2446,7 +2492,8 @@ properties:
             normalizer: clinical_normalizer
             type: keyword
           submitter_id:
-            copy_to: case_autocomplete
+            copy_to:
+            - case_autocomplete
             type: keyword
           updated_datetime:
             normalizer: clinical_normalizer
@@ -2458,7 +2505,8 @@ properties:
         normalizer: clinical_normalizer
         type: keyword
       sample_id:
-        copy_to: case_autocomplete
+        copy_to:
+        - case_autocomplete
         normalizer: clinical_normalizer
         type: keyword
       sample_type:
@@ -2473,7 +2521,8 @@ properties:
         normalizer: clinical_normalizer
         type: keyword
       submitter_id:
-        copy_to: case_autocomplete
+        copy_to:
+        - case_autocomplete
         type: keyword
       time_between_clamping_and_freezing:
         type: long
@@ -2514,7 +2563,8 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   submitter_id:
-    copy_to: case_autocomplete
+    copy_to:
+    - case_autocomplete
     type: keyword
   submitter_portion_ids:
     normalizer: clinical_normalizer

--- a/es-models/gdc_from_graph/descriptions.yaml
+++ b/es-models/gdc_from_graph/descriptions.yaml
@@ -1130,6 +1130,10 @@ _meta:
     cases.follow_ups.molecular_tests.mismatch_repair_mutation: The yes/no/unknown
       indicator used to describe whether the mutation included in molecular testing
       was known to have an affect on the mismatch repair process.
+    cases.follow_ups.molecular_tests.mitotic_count: The number of mitoses identified
+      under the microscope in tumors. The method of counting varies, according to
+      the specific tumor examined. Usually, the mitotic count is determined based
+      on the number of mitoses per high power field (40X) or 10 high power fields.
     cases.follow_ups.molecular_tests.molecular_analysis_method: The text term used
       to describe the method used for molecular analysis.
     cases.follow_ups.molecular_tests.molecular_consequence: The text term used to

--- a/es-models/gdc_from_graph/file.mapping.yaml
+++ b/es-models/gdc_from_graph/file.mapping.yaml
@@ -150,6 +150,9 @@ properties:
               base_caller_version:
                 normalizer: clinical_normalizer
                 type: keyword
+              chipseq_target:
+                normalizer: clinical_normalizer
+                type: keyword
               created_datetime:
                 normalizer: clinical_normalizer
                 type: keyword
@@ -755,6 +758,9 @@ properties:
           diagnosis_id:
             normalizer: clinical_normalizer
             type: keyword
+          eln_risk_classification:
+            normalizer: clinical_normalizer
+            type: keyword
           enneking_msts_grade:
             normalizer: clinical_normalizer
             type: keyword
@@ -932,10 +938,16 @@ properties:
           residual_disease:
             normalizer: clinical_normalizer
             type: keyword
+          satellite_nodule_present:
+            normalizer: clinical_normalizer
+            type: keyword
           secondary_gleason_grade:
             normalizer: clinical_normalizer
             type: keyword
           site_of_resection_or_biopsy:
+            normalizer: clinical_normalizer
+            type: keyword
+          sites_of_involvement:
             normalizer: clinical_normalizer
             type: keyword
           state:
@@ -1056,6 +1068,12 @@ properties:
           weiss_assessment_score:
             normalizer: clinical_normalizer
             type: keyword
+          who_cns_grade:
+            normalizer: clinical_normalizer
+            type: keyword
+          who_nte_grade:
+            normalizer: clinical_normalizer
+            type: keyword
           wilms_tumor_histologic_subtype:
             normalizer: clinical_normalizer
             type: keyword
@@ -1080,6 +1098,9 @@ properties:
             normalizer: clinical_normalizer
             type: keyword
           alcohol_intensity:
+            normalizer: clinical_normalizer
+            type: keyword
+          alcohol_type:
             normalizer: clinical_normalizer
             type: keyword
           asbestos_exposure:
@@ -1122,6 +1143,8 @@ properties:
           secondhand_smoke_as_child:
             normalizer: clinical_normalizer
             type: keyword
+          smokeless_tobacco_quit_age:
+            type: long
           smoking_frequency:
             normalizer: clinical_normalizer
             type: keyword
@@ -1273,7 +1296,13 @@ properties:
             type: keyword
           hiv_viral_load:
             type: long
+          hormonal_contraceptive_type:
+            normalizer: clinical_normalizer
+            type: keyword
           hormonal_contraceptive_use:
+            normalizer: clinical_normalizer
+            type: keyword
+          hormone_replacement_therapy_type:
             normalizer: clinical_normalizer
             type: keyword
           hpv_positive_type:
@@ -1311,6 +1340,8 @@ properties:
               biospecimen_type:
                 normalizer: clinical_normalizer
                 type: keyword
+              biospecimen_volume:
+                type: long
               blood_test_normal_range_lower:
                 type: long
               blood_test_normal_range_upper:
@@ -1359,6 +1390,10 @@ properties:
               mismatch_repair_mutation:
                 normalizer: clinical_normalizer
                 type: keyword
+              mitotic_count:
+                type: long
+              mitotic_total_area:
+                type: long
               molecular_analysis_method:
                 normalizer: clinical_normalizer
                 type: keyword
@@ -1420,6 +1455,9 @@ properties:
           pancreatitis_onset_year:
             type: long
           pregnancy_outcome:
+            normalizer: clinical_normalizer
+            type: keyword
+          procedures_performed:
             normalizer: clinical_normalizer
             type: keyword
           progression_or_recurrence:
@@ -2194,14 +2232,16 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   data_category:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   data_format:
     normalizer: clinical_normalizer
     type: keyword
   data_type:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     type: keyword
   downstream_analyses:
     properties:
@@ -2357,7 +2397,8 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   experimental_strategy:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     type: keyword
   file_autocomplete:
     fields:
@@ -2375,11 +2416,13 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   file_id:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   file_name:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   file_size:
@@ -2506,7 +2549,8 @@ properties:
   magnification:
     type: long
   md5sum:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   mean_coverage:
@@ -2606,7 +2650,8 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   submitter_id:
-    copy_to: file_autocomplete
+    copy_to:
+    - file_autocomplete
     type: keyword
   tags:
     normalizer: clinical_normalizer

--- a/es-models/gdc_from_graph/project.mapping.yaml
+++ b/es-models/gdc_from_graph/project.mapping.yaml
@@ -3,17 +3,20 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   disease_type:
-    copy_to: project_autocomplete
+    copy_to:
+    - project_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   intended_release_date:
     normalizer: clinical_normalizer
     type: keyword
   name:
-    copy_to: project_autocomplete
+    copy_to:
+    - project_autocomplete
     type: keyword
   primary_site:
-    copy_to: project_autocomplete
+    copy_to:
+    - project_autocomplete
     normalizer: clinical_normalizer
     type: keyword
   program:
@@ -42,7 +45,8 @@ properties:
     normalizer: clinical_normalizer
     type: keyword
   project_id:
-    copy_to: project_autocomplete
+    copy_to:
+    - project_autocomplete
     type: keyword
   releasable:
     normalizer: clinical_normalizer


### PR DESCRIPTION
Add new fields introduced in the Very Bad Fish dictionary release to the graph index mappings.

Format `copy_to` as lists, to make it easier to compare the mappings in gdc-models against ones dumped from an existing ES index.