### PR TITLE
DEV-1007: Re-adding fields removed between 2.7.1 and 2.8.1

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2020-07-20T21:45:24Z",
+  "generated_at": "2022-01-28T18:51:57Z",
   "plugins_used": [
     {
       "name": "AWSKeyDetector"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,18 @@
 sudo: true
 language: python
+env:
+  - ES_VERSION="7.7.1"
 python:
   - "2.7"
   - "3.5"
   - "3.7"
 
+before_install:
+  - sudo rm -rf /var/lib/elasticsearch
+
 before_script:
-  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-7.6.2-amd64.deb
-  - sudo dpkg -i --force-confnew elasticsearch-7.6.2-amd64.deb
+  - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-amd64.deb
+  - sudo dpkg -i --force-confnew elasticsearch-${ES_VERSION}-amd64.deb
   - sudo chown elasticsearch /etc/default/elasticsearch
   # Our ES mappings require the mapper-size plugin to be installed
   - sudo /usr/share/elasticsearch/bin/elasticsearch-plugin install mapper-size

--- a/docker-compose-ci.yaml
+++ b/docker-compose-ci.yaml
@@ -1,7 +1,7 @@
 version: "3.3"
 services:
   elasticsearch:
-    image: docker.osdc.io/elasticsearch:7.6.2
+    image: docker.osdc.io/elasticsearch:7.7.1
     environment:
       discovery.type: single-node
       ES_JAVA_OPTS: -Dhttps.proxyHost=cloud-proxy -Dhttps.proxyPort=3128
@@ -16,8 +16,8 @@ services:
       HTTPS_PROXY: http://cloud-proxy:3128
       HTTP_PROXY: http://cloud-proxy:3128
     volumes:
-    - .:/home/jenkins
+      - .:/home/jenkins
     command: bash -c "./wait-for-it.sh localhost:9200 -t 120 && pip install tox -q --user && tox --recreate"
     network_mode: "service:elasticsearch"
-    depends_on: 
+    depends_on:
       - elasticsearch

--- a/es-models/gdc_from_graph/case.mapping.yaml
+++ b/es-models/gdc_from_graph/case.mapping.yaml
@@ -177,6 +177,12 @@ properties:
       ajcc_staging_system_edition:
         normalizer: clinical_normalizer
         type: keyword
+      anaplasia_present:
+        normalizer: clinical_normalizer
+        type: keyword
+      anaplasia_present_type:
+        normalizer: clinical_normalizer
+        type: keyword
       ann_arbor_b_symptoms:
         normalizer: clinical_normalizer
         type: keyword
@@ -246,12 +252,16 @@ properties:
       best_overall_response:
         normalizer: clinical_normalizer
         type: keyword
+      breslow_thickness:
+        type: double
       burkitt_lymphoma_clinical_variant:
         normalizer: clinical_normalizer
         type: keyword
       child_pugh_classification:
         normalizer: clinical_normalizer
         type: keyword
+      circumferential_resection_margin:
+        type: double
       classification_of_tumor:
         normalizer: clinical_normalizer
         type: keyword
@@ -327,6 +337,10 @@ properties:
       goblet_cells_columnar_mucosa_present:
         normalizer: clinical_normalizer
         type: keyword
+      greatest_tumor_dimension:
+        type: long
+      gross_tumor_weight:
+        type: double
       icd_10_code:
         normalizer: clinical_normalizer
         type: keyword
@@ -360,10 +374,23 @@ properties:
       iss_stage:
         normalizer: clinical_normalizer
         type: keyword
+      largest_extrapelvic_peritoneal_focus:
+        normalizer: clinical_normalizer
+        type: keyword
       last_known_disease_status:
         normalizer: clinical_normalizer
         type: keyword
       laterality:
+        normalizer: clinical_normalizer
+        type: keyword
+      lymph_node_involved_site:
+        normalizer: clinical_normalizer
+        type: keyword
+      lymph_nodes_positive:
+        type: long
+      lymph_nodes_tested:
+        type: long
+      lymphatic_invasion_present:
         normalizer: clinical_normalizer
         type: keyword
       margin_distance:
@@ -395,6 +422,12 @@ properties:
       mitotic_count:
         type: long
       morphology:
+        normalizer: clinical_normalizer
+        type: keyword
+      non_nodal_regional_disease:
+        normalizer: clinical_normalizer
+        type: keyword
+      non_nodal_tumor_deposits:
         normalizer: clinical_normalizer
         type: keyword
       ovarian_specimen_status:
@@ -537,6 +570,16 @@ properties:
             normalizer: clinical_normalizer
             type: keyword
         type: nested
+      percent_tumor_invasion:
+        type: double
+      perineural_invasion_present:
+        normalizer: clinical_normalizer
+        type: keyword
+      peripancreatic_lymph_nodes_positive:
+        normalizer: clinical_normalizer
+        type: keyword
+      peripancreatic_lymph_nodes_tested:
+        type: double
       peritoneal_fluid_cytological_status:
         normalizer: clinical_normalizer
         type: keyword
@@ -588,6 +631,9 @@ properties:
         normalizer: clinical_normalizer
         type: keyword
       tissue_or_organ_of_origin:
+        normalizer: clinical_normalizer
+        type: keyword
+      transglottic_extension:
         normalizer: clinical_normalizer
         type: keyword
       treatments:
@@ -674,10 +720,21 @@ properties:
       tumor_grade:
         normalizer: clinical_normalizer
         type: keyword
+      tumor_largest_dimension_diameter:
+        type: double
       tumor_regression_grade:
         normalizer: clinical_normalizer
         type: keyword
+      tumor_stage:
+        normalizer: clinical_normalizer
+        type: keyword
       updated_datetime:
+        normalizer: clinical_normalizer
+        type: keyword
+      vascular_invasion_present:
+        normalizer: clinical_normalizer
+        type: keyword
+      vascular_invasion_type:
         normalizer: clinical_normalizer
         type: keyword
       weiss_assessment_score:
@@ -723,6 +780,8 @@ properties:
       asbestos_exposure:
         normalizer: clinical_normalizer
         type: keyword
+      bmi:
+        type: double
       cigarettes_per_day:
         type: double
       coal_dust_exposure:
@@ -745,6 +804,8 @@ properties:
       exposure_type:
         normalizer: clinical_normalizer
         type: keyword
+      height:
+        type: double
       marijuana_use_per_week:
         type: double
       pack_years_smoked:
@@ -792,6 +853,8 @@ properties:
       updated_datetime:
         normalizer: clinical_normalizer
         type: keyword
+      weight:
+        type: double
       years_smoked:
         type: double
     type: nested
@@ -926,7 +989,11 @@ properties:
                 type: keyword
               proportion_base_mismatch:
                 type: double
+              proportion_coverage_10X:
+                type: double
               proportion_coverage_10x:
+                type: double
+              proportion_coverage_30X:
                 type: double
               proportion_coverage_30x:
                 type: double
@@ -966,6 +1033,8 @@ properties:
             properties:
               read_groups:
                 properties:
+                  RIN:
+                    type: double
                   adapter_name:
                     normalizer: clinical_normalizer
                     type: keyword
@@ -1384,7 +1453,11 @@ properties:
                 type: keyword
               proportion_base_mismatch:
                 type: double
+              proportion_coverage_10X:
+                type: double
               proportion_coverage_10x:
+                type: double
+              proportion_coverage_30X:
                 type: double
               proportion_coverage_30x:
                 type: double
@@ -1538,7 +1611,11 @@ properties:
             type: keyword
           proportion_base_mismatch:
             type: double
+          proportion_coverage_10X:
+            type: double
           proportion_coverage_10x:
+            type: double
+          proportion_coverage_30X:
             type: double
           proportion_coverage_30x:
             type: double
@@ -1647,7 +1724,11 @@ properties:
         type: keyword
       proportion_base_mismatch:
         type: double
+      proportion_coverage_10X:
+        type: double
       proportion_coverage_10x:
+        type: double
+      proportion_coverage_30X:
         type: double
       proportion_coverage_30x:
         type: double

--- a/es-models/gdc_from_graph/descriptions.yaml
+++ b/es-models/gdc_from_graph/descriptions.yaml
@@ -499,6 +499,12 @@ _meta:
       a publication by the group formed for the purpose of developing a system of
       staging for cancer that is acceptable to the American medical profession and
       is compatible with other accepted classifications.
+    cases.diagnoses.anaplasia_present: Yes/no/unknown/not reported indicator used
+      to describe whether anaplasia was present at the time of diagnosis.
+    cases.diagnoses.anaplasia_present_type: The text term used to describe the morphologic
+      findings indicating the presence of a malignant cellular infiltrate characterized
+      by the presence of large pleomorphic cells, necrosis, and high mitotic activity
+      in a tissue sample.
     cases.diagnoses.ann_arbor_b_symptoms: Text term to signify whether lymphoma B-symptoms
       are present as noted in the patient's medical record.
     cases.diagnoses.ann_arbor_b_symptoms_described: Text descibing the specific lymphoma
@@ -538,10 +544,17 @@ _meta:
       the context of a project.
     cases.diagnoses.best_overall_response: The best improvement achieved throughout
       the entire course of protocol treatment.
+    cases.diagnoses.breslow_thickness: The number that describes the distance, in
+      millimeters, between the upper layer of the epidermis and the deepest point
+      of tumor penetration.
     cases.diagnoses.burkitt_lymphoma_clinical_variant: Burkitt's lymphoma categorization
       based on clinical features that differ from other forms of the same disease.
     cases.diagnoses.child_pugh_classification: The text term used to describe the
       classification used in the prognosis of chronic liver disease, mainly cirrhosis.
+    cases.diagnoses.circumferential_resection_margin: Numeric value used to describe
+      the non-peritonealised bare area of rectum, comprising anterior and posterior
+      segments, when submitted as a surgical specimen resulting from excision of cancer
+      of the rectum.
     cases.diagnoses.classification_of_tumor: Text that describes the kind of disease
       present in the tumor specimen as related to a specific timepoint.
     cases.diagnoses.cog_liver_stage: The text term used to describe the staging classification
@@ -616,6 +629,10 @@ _meta:
     cases.diagnoses.goblet_cells_columnar_mucosa_present: The yes/no/unknown indicator
       used to describe whether goblet cells were determined to be present in the esophageal
       columnar mucosa.
+    cases.diagnoses.greatest_tumor_dimension: Numeric value that represents the measurement
+      of the widest portion of the tumor in centimeters.
+    cases.diagnoses.gross_tumor_weight: Numeric value used to describe the gross pathologic
+      tumor weight, measured in grams.
     cases.diagnoses.icd_10_code: Alphanumeric value used to describe the  disease
       code from the tenth version of the International Classification of Disease (ICD-10).
     cases.diagnoses.igcccg_stage: The text term used to describe the International
@@ -646,10 +663,22 @@ _meta:
     cases.diagnoses.ishak_fibrosis_score: The text term used to describe the classification
       of the histopathologic degree of liver damage.
     cases.diagnoses.iss_stage: The multiple myeloma disease stage at diagnosis.
+    cases.diagnoses.largest_extrapelvic_peritoneal_focus: The text term used to describe
+      the diameter of the largest focus originating outside of the pelvic peritoneal
+      region.
     cases.diagnoses.last_known_disease_status: Text term that describes the last known
       state or condition of an individual's neoplasm.
     cases.diagnoses.laterality: For tumors in paired organs, designates the side on
       which the cancer originates.
+    cases.diagnoses.lymph_node_involved_site: The text term used to describe the anatomic
+      site of lymph node involvement.
+    cases.diagnoses.lymph_nodes_positive: The number of lymph nodes involved with
+      disease as determined by pathologic examination.
+    cases.diagnoses.lymph_nodes_tested: The number of lymph nodes tested to determine
+      whether lymph nodes were  involved with disease as determined by a pathologic
+      examination.
+    cases.diagnoses.lymphatic_invasion_present: A yes/no indicator to ask if small
+      or thin-walled vessel invasion is present, indicating lymphatic involvement
     cases.diagnoses.margin_distance: Numeric value that represents the distance between
       the tumor and the surgical margin
     cases.diagnoses.margins_involved_site: The text term used to describe the anatomic
@@ -682,6 +711,11 @@ _meta:
       In pathology, the microscopic process of identifying normal and abnormal morphologic
       characteristics in tissues, by employing various cytochemical and immunocytochemical
       stains. A system of numbered categories for representation of data.
+    cases.diagnoses.non_nodal_regional_disease: The text term used to describe whether
+      the patient had non-nodal regional disease.
+    cases.diagnoses.non_nodal_tumor_deposits: The yes/no/unknown indicator used to
+      describe the presence of tumor deposits in the pericolic or perirectal fat or
+      in adjacent mesentery away from the leading edge of the tumor.
     cases.diagnoses.ovarian_specimen_status: The text term used to describe the physical
       condition of the involved ovary.
     cases.diagnoses.ovarian_surface_involvement: The text term that describes whether
@@ -815,6 +849,15 @@ _meta:
       in a tumor specimen.
     cases.diagnoses.pathology_details.vascular_invasion_type: Text term that represents
       the type of vascular tumor invasion.
+    cases.diagnoses.percent_tumor_invasion: The percentage of tumor cells spread locally
+      in a malignant neoplasm through infiltration or destruction of adjacent tissue.
+    cases.diagnoses.perineural_invasion_present: a yes/no indicator to ask if perineural
+      invasion or infiltration of tumor or cancer is present.
+    cases.diagnoses.peripancreatic_lymph_nodes_positive: Enumerated numeric value
+      or range of values used to describe the number of peripancreatic lymph nodes
+      determined to be positive.
+    cases.diagnoses.peripancreatic_lymph_nodes_tested: The total number of peripancreatic
+      lymph nodes tested for the presence of pancreatic cancer cells.
     cases.diagnoses.peritoneal_fluid_cytological_status: The text term used to describe
       the malignant status of the peritoneal fluid determined by cytologic testing.
     cases.diagnoses.pregnant_at_diagnosis: The text term used to indicate whether
@@ -869,6 +912,8 @@ _meta:
       anatomic site of origin, of the patient's malignant disease, as described by
       the World Health Organization's (WHO) International Classification of Diseases
       for Oncology (ICD-O).
+    cases.diagnoses.transglottic_extension: The text term used to describe an extension
+      of the tumor beyond the opening into the ventricles and vocal cords.
     cases.diagnoses.treatments.batch_id: GDC submission batch indicator. It is unique
       within the context of a project.
     cases.diagnoses.treatments.chemo_concurrent_to_radiation: The text term used to
@@ -930,11 +975,23 @@ _meta:
       disease originated in a single location or multiple locations.
     cases.diagnoses.tumor_grade: Numeric value to express the degree of abnormality
       of cancer cells, a measure of differentiation and aggressiveness.
+    cases.diagnoses.tumor_largest_dimension_diameter: Numeric value used to describe
+      the maximum diameter or dimension of the primary tumor, measured in centimeters.
     cases.diagnoses.tumor_regression_grade: A numeric value used to measure therapeutic
       response of the primary tumor and predict patient outcomes based on a three-point
       tumor regression grading system.
+    cases.diagnoses.tumor_stage: The extent of a cancer in the body. Staging is usually
+      based on the size of the tumor, whether lymph nodes contain cancer, and whether
+      the cancer has spread from the original site to other parts of the body. The
+      accepted values for tumor_stage depend on the tumor site, type, and accepted
+      staging system. These items should accompany the tumor_stage value as associated
+      metadata.
     cases.diagnoses.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+    cases.diagnoses.vascular_invasion_present: The yes/no indicator to ask if large
+      vessel or venous invasion was detected by surgery or presence in a tumor specimen.
+    cases.diagnoses.vascular_invasion_type: Text term that represents the type of
+      vascular tumor invasion.
     cases.diagnoses.weiss_assessment_score: 'The text term used to describe the overall
       Weiss assessment score, a commonly used assessment describing the malignancy
       of adrenocortical tumors. The Weiss score is determined based on nine histological
@@ -969,6 +1026,8 @@ _meta:
       whether the patient was exposed to asbestos.
     cases.exposures.batch_id: GDC submission batch indicator. It is unique within
       the context of a project.
+    cases.exposures.bmi: A calculated numerical quantity that represents an individual's
+      weight to height ratio.
     cases.exposures.cigarettes_per_day: The average number of cigarettes smoked per
       day.
     cases.exposures.coal_dust_exposure: The yes/no/unknown indicator used to describe
@@ -985,6 +1044,7 @@ _meta:
       of exposure, in years.
     cases.exposures.exposure_type: The text term used to describe the type of environmental
       exposure.
+    cases.exposures.height: The height of the patient in centimeters.
     cases.exposures.marijuana_use_per_week: Numeric value that represents the number
       of times the patient uses marijuana each day.
     cases.exposures.pack_years_smoked: Numeric computed value to represent lifetime
@@ -1027,6 +1087,7 @@ _meta:
       type of tobacco used by the patient.
     cases.exposures.updated_datetime: A combination of date and time of day in the
       form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]
+    cases.exposures.weight: The weight of the patient measured in kilograms.
     cases.exposures.years_smoked: Numeric value (or unknown) to represent the number
       of years a person has been smoking.
     cases.family_histories.batch_id: GDC submission batch indicator. It is unique

--- a/es-models/gdc_from_graph/file.mapping.yaml
+++ b/es-models/gdc_from_graph/file.mapping.yaml
@@ -95,7 +95,11 @@ properties:
             type: keyword
           proportion_base_mismatch:
             type: double
+          proportion_coverage_10X:
+            type: double
           proportion_coverage_10x:
+            type: double
+          proportion_coverage_30X:
             type: double
           proportion_coverage_30x:
             type: double
@@ -135,6 +139,8 @@ properties:
         properties:
           read_groups:
             properties:
+              RIN:
+                type: double
               adapter_name:
                 normalizer: clinical_normalizer
                 type: keyword
@@ -649,6 +655,12 @@ properties:
           ajcc_staging_system_edition:
             normalizer: clinical_normalizer
             type: keyword
+          anaplasia_present:
+            normalizer: clinical_normalizer
+            type: keyword
+          anaplasia_present_type:
+            normalizer: clinical_normalizer
+            type: keyword
           ann_arbor_b_symptoms:
             normalizer: clinical_normalizer
             type: keyword
@@ -718,12 +730,16 @@ properties:
           best_overall_response:
             normalizer: clinical_normalizer
             type: keyword
+          breslow_thickness:
+            type: double
           burkitt_lymphoma_clinical_variant:
             normalizer: clinical_normalizer
             type: keyword
           child_pugh_classification:
             normalizer: clinical_normalizer
             type: keyword
+          circumferential_resection_margin:
+            type: double
           classification_of_tumor:
             normalizer: clinical_normalizer
             type: keyword
@@ -799,6 +815,10 @@ properties:
           goblet_cells_columnar_mucosa_present:
             normalizer: clinical_normalizer
             type: keyword
+          greatest_tumor_dimension:
+            type: long
+          gross_tumor_weight:
+            type: double
           icd_10_code:
             normalizer: clinical_normalizer
             type: keyword
@@ -832,10 +852,23 @@ properties:
           iss_stage:
             normalizer: clinical_normalizer
             type: keyword
+          largest_extrapelvic_peritoneal_focus:
+            normalizer: clinical_normalizer
+            type: keyword
           last_known_disease_status:
             normalizer: clinical_normalizer
             type: keyword
           laterality:
+            normalizer: clinical_normalizer
+            type: keyword
+          lymph_node_involved_site:
+            normalizer: clinical_normalizer
+            type: keyword
+          lymph_nodes_positive:
+            type: long
+          lymph_nodes_tested:
+            type: long
+          lymphatic_invasion_present:
             normalizer: clinical_normalizer
             type: keyword
           margin_distance:
@@ -867,6 +900,12 @@ properties:
           mitotic_count:
             type: long
           morphology:
+            normalizer: clinical_normalizer
+            type: keyword
+          non_nodal_regional_disease:
+            normalizer: clinical_normalizer
+            type: keyword
+          non_nodal_tumor_deposits:
             normalizer: clinical_normalizer
             type: keyword
           ovarian_specimen_status:
@@ -1009,6 +1048,16 @@ properties:
                 normalizer: clinical_normalizer
                 type: keyword
             type: nested
+          percent_tumor_invasion:
+            type: double
+          perineural_invasion_present:
+            normalizer: clinical_normalizer
+            type: keyword
+          peripancreatic_lymph_nodes_positive:
+            normalizer: clinical_normalizer
+            type: keyword
+          peripancreatic_lymph_nodes_tested:
+            type: double
           peritoneal_fluid_cytological_status:
             normalizer: clinical_normalizer
             type: keyword
@@ -1060,6 +1109,9 @@ properties:
             normalizer: clinical_normalizer
             type: keyword
           tissue_or_organ_of_origin:
+            normalizer: clinical_normalizer
+            type: keyword
+          transglottic_extension:
             normalizer: clinical_normalizer
             type: keyword
           treatments:
@@ -1146,10 +1198,21 @@ properties:
           tumor_grade:
             normalizer: clinical_normalizer
             type: keyword
+          tumor_largest_dimension_diameter:
+            type: double
           tumor_regression_grade:
             normalizer: clinical_normalizer
             type: keyword
+          tumor_stage:
+            normalizer: clinical_normalizer
+            type: keyword
           updated_datetime:
+            normalizer: clinical_normalizer
+            type: keyword
+          vascular_invasion_present:
+            normalizer: clinical_normalizer
+            type: keyword
+          vascular_invasion_type:
             normalizer: clinical_normalizer
             type: keyword
           weiss_assessment_score:
@@ -1193,6 +1256,8 @@ properties:
           asbestos_exposure:
             normalizer: clinical_normalizer
             type: keyword
+          bmi:
+            type: double
           cigarettes_per_day:
             type: double
           coal_dust_exposure:
@@ -1215,6 +1280,8 @@ properties:
           exposure_type:
             normalizer: clinical_normalizer
             type: keyword
+          height:
+            type: double
           marijuana_use_per_week:
             type: double
           pack_years_smoked:
@@ -1262,6 +1329,8 @@ properties:
           updated_datetime:
             normalizer: clinical_normalizer
             type: keyword
+          weight:
+            type: double
           years_smoked:
             type: double
         type: nested
@@ -2454,7 +2523,11 @@ properties:
             type: keyword
           proportion_base_mismatch:
             type: double
+          proportion_coverage_10X:
+            type: double
           proportion_coverage_10x:
+            type: double
+          proportion_coverage_30X:
             type: double
           proportion_coverage_30x:
             type: double
@@ -2629,7 +2702,11 @@ properties:
         type: keyword
       proportion_base_mismatch:
         type: double
+      proportion_coverage_10X:
+        type: double
       proportion_coverage_10x:
+        type: double
+      proportion_coverage_30X:
         type: double
       proportion_coverage_30x:
         type: double
@@ -2740,7 +2817,11 @@ properties:
     type: keyword
   proportion_base_mismatch:
     type: double
+  proportion_coverage_10X:
+    type: double
   proportion_coverage_10x:
+    type: double
+  proportion_coverage_30X:
     type: double
   proportion_coverage_30x:
     type: double


### PR DESCRIPTION
Added several fields removed between 2.7.1 and 2.8.1 back into es-mapping. The removal of these properties had an unintended consequence of causing some portal graphql queries to fail when validating against the graphql schema. Specifically case and file mappings were updated along with their relevant descriptions.