### PR TITLE
DEV-2498: Update Tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -44,7 +44,7 @@ exclude =
 dev =
     coverage
     elasticsearch-dsl~=7.4
-    importlib-resources
+    importlib-resources;python_version<'3.9'
     pytest
     typing-extensions
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,9 +42,11 @@ exclude =
 
 [options.extras_require]
 dev =
+    coverage
     elasticsearch-dsl~=7.4
-    pytest~=7.0
-    pytest-cov~=4.0
+    importlib-resources
+    pytest
+    typing-extensions
 
 
 [options.entry_points]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,23 +1,25 @@
 import os
 import pathlib
+import tempfile
 from typing import Callable, Iterator
-import pkg_resources
 
 import elasticsearch
+import pkg_resources
 import pytest
 
 
 @pytest.fixture
-def es_models(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+def es_models(monkeypatch: pytest.MonkeyPatch) -> Iterator[pathlib.Path]:
     """Creates a temporary es-models directory and ensures via patching that it is
     loaded by the resources library.
     """
-    models = tmp_path / "es-models"
 
-    models.mkdir()
-    monkeypatch.setattr(pkg_resources, "resource_filename", lambda *_: models)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        models = pathlib.Path(tmp_dir)
 
-    return models
+        monkeypatch.setattr(pkg_resources, "resource_filename", lambda *_: models)
+
+        yield models
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,213 +1,23 @@
-import copy
-import json
 import os
+import pathlib
+from typing import Callable, Iterator
 import pkg_resources
 
 import elasticsearch
 import pytest
-import yaml
-
-import gdcmodels
-
-
-def sample_listdir():
-    es_mappings_dir = pkg_resources.resource_filename('gdcmodels', 'es-models')
-
-    dir_structs = [
-        {
-            'case_centric': ['case_centric.mapping.yaml', 'settings.yaml'],
-            'foo_bar': ['foo_bar.txt', 'foo_bar.py'],
-            'case_set': ['case_set.mapping.yaml', 'settings.yaml'],
-            'gene_centric': ['gene_centric.mapping.yaml', 'settings.yaml'],
-        },
-        {
-            'another': ['another.mapping.yaml', 'settings.yaml'],
-            'foo_bar': ['foo_bar.mapping.yaml', 'settings.yaml'],
-            'case_set': ['case_set.foo.bar', 'settings.yaml'],
-            'gene_centric': ['gene_centric.mapping.yaml', 'settings.yaml'],
-        }
-    ]
-
-    expected = [
-        {
-            'case_centric': {'case_centric', '_settings'},
-            'case_set': {'case_set', '_settings'},
-            'gene_centric': {'gene_centric', '_settings'},
-            'foo_bar': {'_settings'},
-        },
-        {
-            'another': {'another', '_settings'},
-            'foo_bar': {'foo_bar', '_settings'},
-            'case_set': {'_settings'},
-            'gene_centric': {'gene_centric', '_settings'},
-        }
-    ]
-
-    mock_ls = []
-    for ls in dir_structs:
-        dir_content = {
-            os.path.join(es_mappings_dir, key): value
-            for key, value in ls.items()
-        }
-        dir_content[es_mappings_dir] = list(ls.keys())
-
-        mock_ls.append(dir_content)
-
-    return zip(mock_ls, expected)
-
-
-@pytest.fixture(params=sample_listdir())
-def mock_listdir(request, monkeypatch, mock_load_yaml):
-    monkeypatch.setattr(os, 'listdir',
-                        lambda path: request.param[0].get(path, []))
-
-    return request.param[0], request.param[1]
 
 
 @pytest.fixture
-def mock_load_yaml(monkeypatch):
-    monkeypatch.setattr(gdcmodels, 'load_yaml', lambda x: {})
+def es_models(tmp_path: pathlib.Path, monkeypatch: pytest.MonkeyPatch) -> pathlib.Path:
+    """Creates a temporary es-models directory and ensures via patching that it is
+    loaded by the resources library.
+    """
+    models = tmp_path / "es-models"
 
+    models.mkdir()
+    monkeypatch.setattr(pkg_resources, "resource_filename", lambda *_: models)
 
-def write_dict_to_yaml(sub_dir, filename, d):
-    f = sub_dir / filename
-    with f.open("w") as out:
-        yaml.dump(d, out, default_flow_style=False)
-
-
-@pytest.fixture
-def foo_bar_mappings(tmp_path):
-    foo_mapping = {
-        'properties': {
-            'foo': {'type': 'keyword'},
-            'bar': {'type': 'long'},
-        }
-    }
-    foo_settings = {'foo': 1, 'bar': 2}
-    foo_dir_name = 'foo_centric'
-    bar_mapping = {
-        'properties': {
-            'foo': {
-                'type': 'nested',
-                'properties': {
-                    'foofoo': {'type': 'keyword'},
-                    'foobar': {'type': 'keyword'},
-                }
-            },
-            'bar': {'type': 'long'},
-        }
-    }
-    bar_settings = {'foo': 2, 'bar': 4}
-    bar_dir_name = 'bar_centric'
-
-    mapps = {
-        'foo': {'mapping': foo_mapping,
-                'settings': foo_settings,
-                'dir': foo_dir_name},
-        'bar': {'mapping': bar_mapping,
-                'settings': bar_settings,
-                'dir': bar_dir_name},
-    }
-    root = tmp_path
-    return mock_mappings(root, mapps)
-
-
-def mock_mappings(tmp_path, mappings):
-    root = tmp_path
-    expected = {}
-    for mapping_name, data in mappings.items():
-        mapp_dir = root/data['dir']
-        mapp_dir.mkdir()
-        write_dict_to_yaml(mapp_dir, data['dir']+'.mapping.yaml',
-                           data.get('mapping', {}))
-
-        if data.get('settings'):
-            write_dict_to_yaml(mapp_dir, 'settings.yaml',
-                               data.get('settings', {}))
-
-        expected_mapping = copy.deepcopy(data.get('mapping', {}))
-        # descriptions has to be present in payload and descriptions need to
-        # have '_meta' key in them, otherwise they won't be picked up
-        if 'descriptions' in data and data['descriptions'].get('_meta'):
-            desc = data['descriptions']
-            write_dict_to_yaml(mapp_dir, 'descriptions.yaml', desc)
-            expected_mapping.update({'_meta': desc.get('_meta')})
-
-        expected[data['dir']] = {
-            'mapping': expected_mapping,
-            'settings': data.get('settings', {}),
-        }
-
-    return root, expected
-
-
-def get_generic_mapping():
-    foo_mapping = {
-        'properties': {
-            'foo': {'type': 'keyword'},
-            'bar': {'type': 'long'},
-        }
-    }
-    foo_dir_name = 'foo_descriptions'
-    return foo_mapping, foo_dir_name
-
-
-@pytest.fixture
-def descriptions_mappings(tmp_path):
-    foo_mapping, foo_dir_name = get_generic_mapping()
-    descriptions = {'_meta': 'expected_result'}
-    mapps = {
-        'foo': {
-            'mapping': foo_mapping,
-            'dir': foo_dir_name,
-            'descriptions': descriptions,
-        }
-    }
-    root = tmp_path
-    return mock_mappings(root, mapps)
-
-
-@pytest.fixture
-def no_descriptions_mappings(tmp_path):
-    foo_mapping, foo_dir_name = get_generic_mapping()
-    mapps = {
-        'foo': {
-            'mapping': foo_mapping,
-            'dir': foo_dir_name,
-        }
-    }
-    root = tmp_path
-    return mock_mappings(root, mapps)
-
-
-@pytest.fixture
-def empty_descriptions_mappings(tmp_path):
-    foo_mapping, foo_dir_name = get_generic_mapping()
-    descriptions = {}
-    mapps = {
-        'foo': {
-            'mapping': foo_mapping,
-            'dir': foo_dir_name,
-            'descriptions': descriptions,
-        }
-    }
-    root = tmp_path
-    return mock_mappings(root, mapps)
-
-
-@pytest.fixture
-def non_meta_descriptions_mappings(tmp_path):
-    foo_mapping, foo_dir_name = get_generic_mapping()
-    foo_definitions = {'this_property': 'something'}
-    mapps = {
-        'foo': {
-            'mapping': foo_mapping,
-            'dir': foo_dir_name,
-            'descriptions': foo_definitions,
-        }
-    }
-    root = tmp_path
-    return mock_mappings(root, mapps)
+    return models
 
 
 @pytest.fixture(scope="session")
@@ -219,6 +29,18 @@ def es():
 
 
 @pytest.fixture
-def clear_test_indices(es):
+def index_exists(es: elasticsearch.Elasticsearch) -> Callable[[str], bool]:
+    """Returns true if an index exists in elasticsearch."""
+
+    def inner(index: str) -> bool:
+        return es.indices.exists(index=index)
+
+    return inner
+
+
+@pytest.fixture(scope="class")
+def clear_test_indices(es: elasticsearch.Elasticsearch) -> Iterator[None]:
     """Remove any ES indices starting with ``test_`` from the test cluster."""
-    es.indices.delete("test_*")
+    yield None
+
+    es.indices.delete(index="test_*")

--- a/tests/test_init_index.py
+++ b/tests/test_init_index.py
@@ -11,10 +11,10 @@ from typing_extensions import Protocol
 import gdcmodels
 from gdcmodels import init_index
 
-if sys.version_info >= (3, 9):
-    from importlib import resources
-else:
+if sys.version_info < (3, 9):
     import importlib_resources as resources
+else:
+    from importlib import resources
 
 
 class Files(NamedTuple):

--- a/tests/test_init_index.py
+++ b/tests/test_init_index.py
@@ -1,15 +1,20 @@
 import argparse
 import contextlib
+import sys
 from typing import Any, Callable, Iterator, NamedTuple, Optional, Sequence
 
 import elasticsearch
-import importlib_resources as resources
 import pytest
 import yaml
 from typing_extensions import Protocol
 
 import gdcmodels
 from gdcmodels import init_index
+
+if sys.version_info >= (3, 9):
+    from importlib import resources
+else:
+    import importlib_resources as resources
 
 
 class Files(NamedTuple):

--- a/tests/test_init_index.py
+++ b/tests/test_init_index.py
@@ -1,22 +1,102 @@
-import pkg_resources
+import argparse
+import contextlib
+from typing import Any, Callable, Iterator, NamedTuple, Optional, Sequence
 
+import elasticsearch
+import importlib_resources as resources
 import pytest
 import yaml
+from typing_extensions import Protocol
 
+import gdcmodels
 from gdcmodels import init_index
 
 
-pytestmark = pytest.mark.usefixtures("clear_test_indices")
+class Files(NamedTuple):
+    mapping: str
+    settings: str
+    descriptions: Optional[str] = None
 
 
-def load_yaml(package_name, resource_name):
+class Models:
+    """The file paths for all models/indices."""
+
+    class Graph:
+        ANNOTATION = Files(
+            "es-models/gdc_from_graph/annotation.mapping.yaml",
+            "es-models/gdc_from_graph/settings.yaml",
+            "es-models/gdc_from_graph/descriptions.yaml",
+        )
+        CASE = Files(
+            "es-models/gdc_from_graph/case.mapping.yaml",
+            "es-models/gdc_from_graph/settings.yaml",
+            "es-models/gdc_from_graph/descriptions.yaml",
+        )
+        FILE = Files(
+            "es-models/gdc_from_graph/file.mapping.yaml",
+            "es-models/gdc_from_graph/settings.yaml",
+            "es-models/gdc_from_graph/descriptions.yaml",
+        )
+        PROJECT = Files(
+            "es-models/gdc_from_graph/project.mapping.yaml",
+            "es-models/gdc_from_graph/settings.yaml",
+            "es-models/gdc_from_graph/descriptions.yaml",
+        )
+
+    class Viz:
+        CASE_CENTRIC = Files(
+            "es-models/case_centric/case_centric.mapping.yaml",
+            "es-models/case_centric/settings.yaml",
+        )
+        CNV_CENTRIC = Files(
+            "es-models/cnv_centric/cnv_centric.mapping.yaml",
+            "es-models/cnv_centric/settings.yaml",
+        )
+        CNV_OCCURRENCE_CENTRIC = Files(
+            "es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml",
+            "es-models/cnv_occurrence_centric/settings.yaml",
+        )
+        GENE_CENTRIC = Files(
+            "es-models/gene_centric/gene_centric.mapping.yaml",
+            "es-models/gene_centric/settings.yaml",
+        )
+        SSM_CENTRIC = Files(
+            "es-models/ssm_centric/ssm_centric.mapping.yaml",
+            "es-models/ssm_centric/settings.yaml",
+        )
+        SSM_OCCURRENCE_CENTRIC = Files(
+            "es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml",
+            "es-models/ssm_occurrence_centric/settings.yaml",
+        )
+
+    class Sets:
+        CASE = Files(
+            "es-models/case_set/case_set.mapping.yaml", "es-models/case_set/settings.yaml"
+        )
+        FILE = Files(
+            "es-models/file_set/file_set.mapping.yaml", "es-models/file_set/settings.yaml"
+        )
+        GENE = Files(
+            "es-models/gene_set/gene_set.mapping.yaml", "es-models/gene_set/settings.yaml"
+        )
+        SSM = Files("es-models/ssm_set/ssm_set.mapping.yaml", "es-models/ssm_set/settings.yaml")
+
+
+def load_yaml(resource_name: str) -> dict:
     """Load the YAML data from the given resource."""
-    with pkg_resources.resource_stream(package_name, resource_name) as yaml_in:
-        return yaml.safe_load(yaml_in)
+    resource = resources.files(gdcmodels) / resource_name
+
+    return yaml.safe_load(resource.read_bytes())
 
 
-@pytest.fixture(scope="session")
-def get_args(es):
+class GetArgs(Protocol):
+    """A function for parsing the given arges into a Namespace."""
+
+    def __call__(self, *args: str) -> argparse.Namespace: ...
+
+
+@pytest.fixture(scope="class")
+def get_args(es: elasticsearch.Elasticsearch) -> GetArgs:
     """Create a function that parses args for `init_index`.
 
     Use the actual arg parser because it's less work than writing a dummy args class
@@ -25,46 +105,46 @@ def get_args(es):
     """
 
     # Assume we only configured one host for the ES client fixture.
-    host_info = es.transport.hosts[0]
-    es_args = ["--host", host_info["host"], "--port", str(host_info["port"])]
+    assert es.transport.hosts
 
-    def parse(*args):
-        actual_args = es_args + list(args)
+    host_info = es.transport.hosts[0]
+    es_args = ("--host", host_info["host"], "--port", str(host_info["port"]))
+
+    def parse(*args: str) -> argparse.Namespace:
+        actual_args = (*es_args, *args)
         return init_index.get_parser().parse_args(actual_args)
 
     return parse
 
 
-@pytest.fixture(scope="session")
-def validate_index(es):
+Validate = Callable[[str, Files], None]
+
+
+@pytest.fixture
+def validate_index(es: elasticsearch.Elasticsearch) -> Validate:
     """Create a validator for the successful creation and setup of an ES index."""
 
-    def validator(
-        index_name, mapping_resource, settings_resource, descriptions_resource=None
-    ):
+    def validator(index_name: str, files: Files) -> None:
         """Verify an ES index was created and configured as expected.
 
         Args:
-            index_name (str): Name of the index to validate.
-            mapping_resource (str): Resource name with expected mapping YAML.
-            settings_resource (str): Resource name with expected settings YAML.
-            descriptions_resource (optional(str)): Resource name with expected
-                descriptions YAML, or None to expect no descriptions.
+            index_name: Name of the index to validate.
+            files: The model files associated with the given index.
         """
-        index_info = es.indices.get(index_name)
+        index_info = es.indices.get(index=index_name)
         assert index_info is not None, f"Index {index_name} does not exist"
         assert index_name in index_info
 
-        expected_mapping = load_yaml("gdcmodels", mapping_resource)
-        if descriptions_resource:
-            expected_mapping.update(load_yaml("gdcmodels", descriptions_resource))
+        expected_mapping = load_yaml(files.mapping)
+        if files.descriptions:
+            expected_mapping.update(load_yaml(files.descriptions))
 
         assert index_info[index_name]["mappings"] == expected_mapping
 
         # Elasticsearch adds some junk to the actual index settings, and we also rely
         # on it to flatten some things out, so just check that a couple things line up
         # rather than try to verify an exact match.
-        expected_settings = load_yaml("gdcmodels", settings_resource)
+        expected_settings = load_yaml(files.settings)
         actual_settings = index_info[index_name]["settings"]["index"]
 
         assert int(actual_settings["max_result_window"]) == (
@@ -88,21 +168,10 @@ def validate_index(es):
 
 
 @pytest.fixture
-def preexisting_case_set(es, clear_test_indices):
-    """Create a ``test_case_set`` index with the case index's mapping and settings.
-
-    Explicitly depend on ``clear_test_indices`` to force the right fixture order.
-    """
-    mapping = load_yaml("gdcmodels", "es-models/gdc_from_graph/case.mapping.yaml")
-    settings = load_yaml("gdcmodels", "es-models/gdc_from_graph/settings.yaml")
-    es.indices.create("test_case_set", body={"mappings": mapping, "settings": settings})
-
-
-@pytest.fixture
-def patch_input(monkeypatch):
+def patch_input(monkeypatch: pytest.MonkeyPatch) -> Callable[[str], None]:
     """Create a function to patch user input in the `init_index` module."""
 
-    def apply_patch(user_input):
+    def apply_patch(user_input: str) -> None:
         def return_input(*args, **kwargs):
             return user_input
 
@@ -113,88 +182,156 @@ def patch_input(monkeypatch):
 
 @pytest.mark.parametrize(
     "args",
-    [
-        ["--prefix", "foo-bar"],
-        ["--prefix", "foo-bar", "--host", "localhost"],
-        ["--prefix", "foo-bar", "--index", "case_centric"],
-        ["--index", "case_centric", "gene_centric"],
-        ["--index", "case_centric", "--host", "localhost"],
-        ["--host", "localhost"],
-    ],
+    (
+        ("--prefix", "foo-bar"),
+        ("--prefix", "foo-bar", "--host", "localhost"),
+        ("--prefix", "foo-bar", "--index", "case_centric"),
+        ("--index", "case_centric", "gene_centric"),
+        ("--index", "case_centric", "--host", "localhost"),
+        ("--host", "localhost"),
+    ),
 )
-def test_get_parser__requires_args(args):
+def test_get_parser__requires_args(args: Sequence[str]) -> None:
     """Test that `get_parser` aborts if certain arguments are missing."""
     with pytest.raises(SystemExit):
         init_index.get_parser().parse_args(args)
 
 
-def test_init_index__creates_graph_indices(get_args, validate_index):
-    """Verify `init_index` can create the active graph indices correctly.
-
-    Expect the names to be ``test_gdc_from_graph...`` because that's how the init logic
-    works, even though it's not how we'd normally name the indices. We don't normally
-    use this init script to create the graph index anyway (we let esbuild do it).
-    """
+@pytest.fixture(scope="class")
+def create_graph_indices(get_args: GetArgs, clear_test_indices: Any) -> None:
     args = get_args("--index", "gdc_from_graph", "--prefix", "test")
+
     init_index.init_index(args)
 
-    validate_index(
-        index_name="test_gdc_from_graph_annotation",
-        mapping_resource="es-models/gdc_from_graph/annotation.mapping.yaml",
-        settings_resource="es-models/gdc_from_graph/settings.yaml",
-        descriptions_resource="es-models/gdc_from_graph/descriptions.yaml",
+
+@pytest.mark.usefixtures("create_graph_indices")
+class TestGraphIndices:
+
+    @pytest.mark.parametrize(
+        ("index", "files"),
+        (
+            pytest.param(
+                "test_gdc_from_graph_annotation", Models.Graph.ANNOTATION, id="annotation"
+            ),
+            pytest.param("test_gdc_from_graph_case", Models.Graph.CASE, id="case"),
+            pytest.param("test_gdc_from_graph_file", Models.Graph.FILE, id="file"),
+            pytest.param("test_gdc_from_graph_project", Models.Graph.PROJECT, id="project"),
+        ),
     )
-    validate_index(
-        index_name="test_gdc_from_graph_case",
-        mapping_resource="es-models/gdc_from_graph/case.mapping.yaml",
-        settings_resource="es-models/gdc_from_graph/settings.yaml",
-        descriptions_resource="es-models/gdc_from_graph/descriptions.yaml",
-    )
-    validate_index(
-        index_name="test_gdc_from_graph_file",
-        mapping_resource="es-models/gdc_from_graph/file.mapping.yaml",
-        settings_resource="es-models/gdc_from_graph/settings.yaml",
-        descriptions_resource="es-models/gdc_from_graph/descriptions.yaml",
-    )
-    validate_index(
-        index_name="test_gdc_from_graph_project",
-        mapping_resource="es-models/gdc_from_graph/project.mapping.yaml",
-        settings_resource="es-models/gdc_from_graph/settings.yaml",
-        descriptions_resource="es-models/gdc_from_graph/descriptions.yaml",
-    )
+    @pytest.mark.usefixtures("create_graph_indices")
+    def test_init_index__creates_graph_indices(
+        self, validate_index: Validate, index: str, files: Files
+    ) -> None:
+        """Verify `init_index` can create the active graph indices correctly.
+
+        Expect the names to be ``test_gdc_from_graph...`` because that's how the init logic
+        works, even though it's not how we'd normally name the indices. We don't normally
+        use this init script to create the graph index anyway (we let esbuild do it).
+        """
+        validate_index(index, files)
 
 
-def test_init_index__creates_set_indices(get_args, validate_index):
-    """Verify `init_index` can create the saved set indices correctly."""
+@pytest.fixture(scope="class")
+def create_set_indices(get_args: GetArgs, clear_test_indices: Any) -> None:
     args = get_args(
-        "--index", "case_set", "file_set", "gene_set", "ssm_set", "--prefix", "test_set"
+        "--index",
+        "case_set",
+        "file_set",
+        "gene_set",
+        "ssm_set",
+        "awg_centric",  # unknown index
+        "--prefix",
+        "test_set",
     )
+
     init_index.init_index(args)
 
-    validate_index(
-        index_name="test_set_case_set",
-        mapping_resource="es-models/case_set/case_set.mapping.yaml",
-        settings_resource="es-models/case_set/settings.yaml",
-    )
-    validate_index(
-        index_name="test_set_file_set",
-        mapping_resource="es-models/file_set/file_set.mapping.yaml",
-        settings_resource="es-models/file_set/settings.yaml",
-    )
-    validate_index(
-        index_name="test_set_gene_set",
-        mapping_resource="es-models/gene_set/gene_set.mapping.yaml",
-        settings_resource="es-models/gene_set/settings.yaml",
-    )
-    validate_index(
-        index_name="test_set_ssm_set",
-        mapping_resource="es-models/ssm_set/ssm_set.mapping.yaml",
-        settings_resource="es-models/ssm_set/settings.yaml",
-    )
+
+RecreateIndex = Callable[[Sequence[str], Optional[str]], None]
 
 
-def test_init_index__creates_viz_indices(get_args, validate_index):
-    """Verify `init_index` can create the visualization indices correctly."""
+@pytest.fixture
+def recreate_index(get_args: GetArgs, patch_input: Callable[[str], None]) -> RecreateIndex:
+    def inner(args: Sequence[str], user_input: Optional[str]) -> None:
+        if user_input is not None:
+            patch_input(user_input)
+
+        init_index.init_index(get_args(*args))
+
+    return inner
+
+
+@pytest.mark.usefixtures("create_set_indices")
+class TestSetsIndices:
+    @pytest.fixture(autouse=True)
+    def init_fixtures(
+        self,
+        es: elasticsearch.Elasticsearch,
+    ) -> None:
+        self._es = es
+
+    @contextlib.contextmanager
+    def _create_set(self, index: str, ids: Sequence[str]) -> Iterator[str]:
+        response = self._es.index(index=index, document={"ids": ids}, refresh=True)
+        id = response["_id"]
+
+        yield id
+
+        self._es.delete(index=index, id=id, ignore=404)
+
+    @pytest.mark.parametrize(
+        ("index", "files"),
+        (
+            pytest.param("test_set_case_set", Models.Sets.CASE, id="case_set"),
+            pytest.param("test_set_file_set", Models.Sets.FILE, id="file_set"),
+            pytest.param("test_set_gene_set", Models.Sets.GENE, id="gene_set"),
+            pytest.param("test_set_ssm_set", Models.Sets.SSM, id="ssm_set"),
+        ),
+    )
+    def test_init_index__creates_set_indices(
+        self, validate_index: Validate, index: str, files: Files
+    ) -> None:
+        """Verify `init_index` can create the saved set indices correctly."""
+
+        validate_index(index, files)
+
+    def test_init_index__ignores_unknown_indices(
+        self, index_exists: Callable[[str], bool]
+    ) -> None:
+        """Confirm unknown indices are ignored, and do not block creating known indices."""
+        assert not index_exists("awg_centric")
+
+    def test_init_index__skips_existing_indices(self, recreate_index: RecreateIndex) -> None:
+        """Confirm existing indices are not recreated when ``--delete`` is not passed."""
+
+        with self._create_set("test_case_set", ("case-0", "case-1")) as set_id:
+            recreate_index(("--index", "case_set", "--prefix", "test"), None)
+
+            assert self._es.exists(index="test_case_set", id=set_id)
+
+    @pytest.mark.parametrize("user_input", ["case_set", "test_case_settee", "NO", ""])
+    def test_init_index__skips_if_prompt_doesnt_match(
+        self, recreate_index: RecreateIndex, user_input: str
+    ) -> None:
+        """Confirm ``--delete`` does not delete indices if the confirmation prompt fails."""
+        with self._create_set("test_case_set", ("case-0", "case-1")) as set_id:
+            recreate_index(("--index", "case_set", "--prefix", "test", "--delete"), user_input)
+
+            assert self._es.exists(index="test_case_set", id=set_id)
+
+    def test_init_index__deletes_if_prompt_matches(self, recreate_index: RecreateIndex) -> None:
+        """Confirm ``--delete`` deletes and recreates indices if the prompt passes."""
+
+        with self._create_set("test_case_set", ("case-0", "case-1")) as set_id:
+            recreate_index(
+                ("--index", "case_set", "--prefix", "test", "--delete"), "test_case_set"
+            )
+
+            assert not self._es.exists(index="test_case_set", id=set_id)
+
+
+@pytest.fixture(scope="class")
+def create_viz_indices(get_args: GetArgs, clear_test_indices: Any) -> None:
     args = get_args(
         "--index",
         "case_centric",
@@ -206,106 +343,34 @@ def test_init_index__creates_viz_indices(get_args, validate_index):
         "--prefix",
         "test_viz",
     )
+
     init_index.init_index(args)
 
-    validate_index(
-        index_name="test_viz_case_centric",
-        mapping_resource="es-models/case_centric/case_centric.mapping.yaml",
-        settings_resource="es-models/case_centric/settings.yaml",
-    )
-    validate_index(
-        index_name="test_viz_cnv_centric",
-        mapping_resource="es-models/cnv_centric/cnv_centric.mapping.yaml",
-        settings_resource="es-models/cnv_centric/settings.yaml",
-    )
-    validate_index(
-        index_name="test_viz_cnv_occurrence_centric",
-        mapping_resource=(
-            "es-models/cnv_occurrence_centric/cnv_occurrence_centric.mapping.yaml"
+
+@pytest.mark.usefixtures("create_viz_indices")
+class TestVizIndices:
+
+    @pytest.mark.parametrize(
+        ("index", "files"),
+        (
+            pytest.param("test_viz_case_centric", Models.Viz.CASE_CENTRIC, id="case_centric"),
+            pytest.param("test_viz_cnv_centric", Models.Viz.CNV_CENTRIC, id="cnv_centric"),
+            pytest.param(
+                "test_viz_cnv_occurrence_centric",
+                Models.Viz.CNV_OCCURRENCE_CENTRIC,
+                id="cnv_occurrence_centric",
+            ),
+            pytest.param("test_viz_gene_centric", Models.Viz.GENE_CENTRIC, id="gene_centric"),
+            pytest.param("test_viz_ssm_centric", Models.Viz.SSM_CENTRIC, id="ssm_centric"),
+            pytest.param(
+                "test_viz_ssm_occurrence_centric",
+                Models.Viz.SSM_OCCURRENCE_CENTRIC,
+                id="ssm_occurrence_centric",
+            ),
         ),
-        settings_resource="es-models/cnv_occurrence_centric/settings.yaml",
     )
-    validate_index(
-        index_name="test_viz_gene_centric",
-        mapping_resource="es-models/gene_centric/gene_centric.mapping.yaml",
-        settings_resource="es-models/gene_centric/settings.yaml",
-    )
-    validate_index(
-        index_name="test_viz_ssm_centric",
-        mapping_resource="es-models/ssm_centric/ssm_centric.mapping.yaml",
-        settings_resource="es-models/ssm_centric/settings.yaml",
-    )
-    validate_index(
-        index_name="test_viz_ssm_occurrence_centric",
-        mapping_resource=(
-            "es-models/ssm_occurrence_centric/ssm_occurrence_centric.mapping.yaml"
-        ),
-        settings_resource="es-models/ssm_occurrence_centric/settings.yaml",
-    )
-
-
-def test_init_index__ignores_unknown_indices(get_args, validate_index):
-    """Confirm unknown indices are ignored, and do not block creating known indices."""
-    args = get_args(
-        "--index", "awg_centric", "case_set", "cnv_set", "file_set", "--prefix", "test"
-    )
-    init_index.init_index(args)
-
-    validate_index(
-        index_name="test_case_set",
-        mapping_resource="es-models/case_set/case_set.mapping.yaml",
-        settings_resource="es-models/case_set/settings.yaml",
-    )
-    validate_index(
-        index_name="test_file_set",
-        mapping_resource="es-models/file_set/file_set.mapping.yaml",
-        settings_resource="es-models/file_set/settings.yaml",
-    )
-
-
-@pytest.mark.usefixtures("preexisting_case_set")
-def test_init_index__skips_existing_indices(get_args, validate_index):
-    """Confirm existing indices are not recreated when ``--delete`` is not passed."""
-    args = get_args("--index", "case_set", "--prefix", "test")
-    init_index.init_index(args)
-
-    # The preexisting test_case_set should have the graph case mapping/settings.
-    validate_index(
-        index_name="test_case_set",
-        mapping_resource="es-models/gdc_from_graph/case.mapping.yaml",
-        settings_resource="es-models/gdc_from_graph/settings.yaml",
-    )
-
-
-@pytest.mark.parametrize("user_input", ["case_set", "test_case_settee", "NO", ""])
-@pytest.mark.usefixtures("preexisting_case_set")
-def test_init_index__skips_if_prompt_doesnt_match(
-    get_args, validate_index, patch_input, user_input
-):
-    """Confirm ``--delete`` does not delete indices if the confirmation prompt fails."""
-    patch_input(user_input)
-
-    args = get_args("--index", "case_set", "--prefix", "test", "--delete")
-    init_index.init_index(args)
-
-    validate_index(
-        index_name="test_case_set",
-        mapping_resource="es-models/gdc_from_graph/case.mapping.yaml",
-        settings_resource="es-models/gdc_from_graph/settings.yaml",
-    )
-
-
-@pytest.mark.usefixtures("preexisting_case_set")
-def test_init_index__deletes_if_prompt_matches(get_args, validate_index, patch_input):
-    """Confirm ``--delete`` deletes and recreates indices if the prompt passes."""
-    patch_input("test_case_set")
-
-    args = get_args("--index", "case_set", "--prefix", "test", "--delete")
-    init_index.init_index(args)
-
-    # init_index should have recreated the case set index with the proper settings.
-    validate_index(
-        index_name="test_case_set",
-        mapping_resource="es-models/case_set/case_set.mapping.yaml",
-        settings_resource="es-models/case_set/settings.yaml",
-    )
+    def test_init_index__creates_viz_indices(
+        self, validate_index: Validate, index: str, files: Files
+    ) -> None:
+        """Verify `init_index` can create the visualization indices correctly."""
+        validate_index(index, files)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,40 @@
+import pathlib
+from typing import Optional
+
+import yaml
+
+
+def load_model(
+    models: pathlib.Path,
+    index_name: str,
+    mapping: dict,
+    settings: dict,
+    doc_type: Optional[str] = None,
+    descriptions: Optional[dict] = None,
+) -> None:
+    """A util for loading an index/doc_type into the given models directory.
+
+    Args:
+        models: The directory containing all models.
+        index_name: The name of the index to be created.
+        mapping: The mappings to be associated with the doc_type.
+        settings: The settings to be associated with the index.
+        doc_type: The name of the doc_type within the index. By default this value is
+            set to index_name if no value is provided.
+        description: The descriptions associated with the index.
+        vestigial: The vestigial properties associated with the doc_type mapping.
+    """
+    index_dir = models / index_name
+    doc_type = doc_type or index_name
+
+    index_dir.mkdir(parents=True, exist_ok=True)
+
+    with open(index_dir / f"{doc_type}.mapping.yaml", "w+") as f:
+        yaml.safe_dump(mapping, f)
+
+    with open(index_dir / "settings.yaml", "w+") as f:
+        yaml.safe_dump(settings, f)
+
+    if descriptions is not None:
+        with open(index_dir / "descriptions.yaml", "w+") as f:
+            yaml.safe_dump(descriptions, f)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,10 @@ extras =
 usedevelop=true
 commands =
     python ./scripts/git-hooks/pre-commit
-    pytest -vvs --cov=gdcmodels --cov-report xml --cov-report html --junit-xml test-reports/results.xml {tty:--color=yes} {posargs}
+    coverage run --source gdcmodels -m pytest -vvs --junitxml test-reports/results.xml {tty:--color=yes} {posargs}
+    coverage xml
+    coverage html
+    coverage report -m
 
 [testenv:coverage]
 passenv = CODACY_PROJECT_TOKEN

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ extras =
 usedevelop=true
 commands =
     python ./scripts/git-hooks/pre-commit
-    coverage run --source gdcmodels -m pytest -vvs --junitxml test-reports/results.xml {tty:--color=yes} {posargs}
+    coverage run --source gdcmodels -m pytest -vvs --junit-xml test-reports/results.xml {tty:--color=yes} {posargs}
     coverage xml
     coverage html
     coverage report -m


### PR DESCRIPTION
This updates the tests to better abstract away the parts of them that will have to change when the new model directory structuring is introduced with this story.

Updates:

- Move single-use test fixture logic to inside the test in order to allow for clearer understanding of what the test setup looks like and therefore what is being tested.
- Introduce constants file paths withing es-models.
- Switch to `importlib_resource` vs depreciated `pkg_resources`
- Mock `pkg_resources` with a temp dir vs passing a directory directly. (This functionality appears only in test and will be phased out in code change)

NOTE: `pytest-cov` was causing issues in gitlab. It couldn't resolve the version for some reason. I was able to get around this by opting to use coverage direct.