### PR TITLE
DEV-2677: Add curated model index to excluded fields.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,8 +49,8 @@ dev =
     pytest
 sync =
     click
-    gdcdictionary
-    gdcdatamodel2
+    gdcdictionary~=3.0.0
+    gdcdatamodel2~=3.0.0
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
This change ensures that the new `curated_model_index` is not included in the generated mappings. It slightly refactors the code so logic calling the `_load_properties_from` function can control what fields are ignored.