### PR TITLE
DEV-3186: remove sample property from observation in segment_cnv_centric

### DIFF
--- a/src/gdcmodels/esmodels/segment_cnv_centric/mapping.yaml
+++ b/src/gdcmodels/esmodels/segment_cnv_centric/mapping.yaml
@@ -489,14 +489,6 @@ properties:
               observation_id:
                 normalizer: clinical_normalizer
                 type: keyword
-              sample:
-                properties:
-                  tumor_sample_barcode:
-                    normalizer: clinical_normalizer
-                    type: keyword
-                  tumor_sample_uuid:
-                    normalizer: clinical_normalizer
-                    type: keyword
               sample_ploidy_integer:
                 type: integer
               src_file_id:


### PR DESCRIPTION
The initial mapping file was basically copied from the cnv_centric mapping, and the sample field is not required for segment_cnv_centric. The sample property is also not indexed in the cnv_centric index.